### PR TITLE
Added an entity properties to route placeholders mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versions prior to 0.4.0 were released as the package "weierophinney/hal".
 
 ### Added
 
-- Nothing.
+- [#13](https://github.com/mezzio/mezzio-hal/pull/13) adds a new configuration key, `identifiers_to_placeholders_mapping`, for use with the `RouteBasedResourceMetadata`. The setting is an associative array mapping resource properties/identifiers to the route placeholders they should fill. The setting corresponds to an optional seventh argument to the `RouteBasedResourceMetadata` class, and can be used to replace and extend the `$routeIdentifierPlaceholder` argument and corresponding `route_identifier_placeholder` configuration; it is more flexible, as it allows more than a single mapping to occur.
 
 ### Changed
 
@@ -16,7 +16,7 @@ Versions prior to 0.4.0 were released as the package "weierophinney/hal".
 
 ### Deprecated
 
-- Nothing.
+- [#13](https://github.com/mezzio/mezzio-hal/pull/13) deprecates both the `RouteBasedResourceMetadata` class `$routeIdentifierPlaceholder` argument and related `route_identifier_placeholder` setting. Please update your code to use the new `$identifiersToPlaceholders` argument and related `identifiers_to_placeholders_mapping` configuration instead. The argument and configuration key will be removed in version 2.0.0.
 
 ### Removed
 

--- a/docs/book/factories.md
+++ b/docs/book/factories.md
@@ -109,6 +109,7 @@ The additional pairs are as follows:
       represents the resource identifier; defaults to "id".
     - `route_params`: an array of additional routing parameters to use when
       generating the self relational link for the resource.
+    - `identifiers_to_placeholders_mapping` (associative array mapping resource properties to routing parameters, for use when generating the URI)
 - For `RouteBasedCollectionMetadata`:
     - `collection_class`: the collection class the metadata describes.
     - `collection_relation`: the embedded relation for the collection in the
@@ -134,13 +135,13 @@ type you wish to support, where `<type>` is your custom class name, minus
 the namespace.
 
 > ### Limitation
-> 
+>
 > There is a [known limitation](https://github.com/zendframework/zend-expressive-hal/issues/5)
 > with laminas-router when using routes with optional parameters (e.g., `/books[/:id]`,
 > where `:id` is optional). In such cases, if no matching parameter is provided
 > (such as when generating a URI without an `:id`), the router will raise an
 > exception due to the missing parameter.
-> 
+>
 > If you encounter this issue, create separate routing entries for each optional
 > parameter. See the issue for a comprehensive example.
 

--- a/docs/book/factories.md
+++ b/docs/book/factories.md
@@ -106,10 +106,11 @@ The additional pairs are as follows:
     - `resource_identifier`: what property in the resource represents its
       identifier; defaults to "id".
     - `route_identifier_placeholder`: what placeholder in the route string
-      represents the resource identifier; defaults to "id".
+      represents the resource identifier; defaults to "id". Deprecated since
+      1.4.0; use the `identifiers_to_placeholders_mapping` setting instead.
     - `route_params`: an array of additional routing parameters to use when
       generating the self relational link for the resource.
-    - `identifiers_to_placeholders_mapping` (associative array mapping resource properties to routing parameters, for use when generating the URI)
+    - `identifiers_to_placeholders_mapping` (associative array mapping resource properties to routing parameters, for use when generating the URI; since 1.4.0)
 - For `RouteBasedCollectionMetadata`:
     - `collection_class`: the collection class the metadata describes.
     - `collection_relation`: the embedded relation for the collection in the

--- a/docs/book/resource-generator.md
+++ b/docs/book/resource-generator.md
@@ -50,6 +50,7 @@ following information:
       that maps to the resource identifier)
     - array `$routeParams = []` (associative array of additional routing
       parameters to substitute when generating the URI)
+    - array `$identifiersToPlacholdersMapping = []` (associative array mapping resource properties to route parameters, for use when generating the URI; available since 1.4.0)
 - `Mezzio\Hal\Metadata\UrlBasedCollectionMetadata`:
     - string `$class`
     - string `$collectionRelation`
@@ -127,6 +128,7 @@ The rest of the parameters follow underscore delimiter naming convention:
     - `resource_identifier` (name of the property uniquely identifying the resource)
     - `route_identifier_placeholder` (name of the routing parameter that maps to the resource identifier)
     - `route_params` (associative array of substitutions to use with the designated route)
+    - `identifiers_to_placeholders_mapping` (associative array mapping resource properties to routing parameters, for use when generating the URI)
 - `RouteBasedCollectionMetadata::class`
     - `pagination_param`  (name of the parameter indicating the current page of results)
     - `pagination_param_type` (one of "query" or "placeholder")

--- a/docs/book/resource-generator.md
+++ b/docs/book/resource-generator.md
@@ -47,7 +47,8 @@ following information:
     - string `$resourceIdentifier = 'id'` (name of the property uniquely
       identifying the resource)
     - string `$routeIdentifierPlaceholder = 'id'` (name of the routing parameter
-      that maps to the resource identifier)
+      that maps to the resource identifier; deprecated since 1.4.0 in favor of
+      using the `$identifiersToPlacholdersMapping`)
     - array `$routeParams = []` (associative array of additional routing
       parameters to substitute when generating the URI)
     - array `$identifiersToPlacholdersMapping = []` (associative array mapping resource properties to route parameters, for use when generating the URI; available since 1.4.0)
@@ -126,9 +127,9 @@ The rest of the parameters follow underscore delimiter naming convention:
 
 - `RouteBasedResourceMetadata::class`
     - `resource_identifier` (name of the property uniquely identifying the resource)
-    - `route_identifier_placeholder` (name of the routing parameter that maps to the resource identifier)
+    - `route_identifier_placeholder` (name of the routing parameter that maps to the resource identifier. Deprecated since 1.4.0; use the `identifiers_to_placeholders_mapping` setting instead)
     - `route_params` (associative array of substitutions to use with the designated route)
-    - `identifiers_to_placeholders_mapping` (associative array mapping resource properties to routing parameters, for use when generating the URI)
+    - `identifiers_to_placeholders_mapping` (associative array mapping resource properties to routing parameters, for use when generating the URI; since 1.4.0)
 - `RouteBasedCollectionMetadata::class`
     - `pagination_param`  (name of the parameter indicating the current page of results)
     - `pagination_param_type` (one of "query" or "placeholder")

--- a/src/Metadata/Exception/InvalidConfigException.php
+++ b/src/Metadata/Exception/InvalidConfigException.php
@@ -101,4 +101,20 @@ class InvalidConfigException extends RuntimeException implements ExceptionInterf
             implode(', ', $requiredKeys)
         ));
     }
+
+    public static function dueToConflictingRouteIdentifierPlaceholder(
+        string $resourceIdentifier,
+        string $routeIdentifierPlaceholder,
+        string $routeIdentifierPlaceholderFromMapping
+    ) : self {
+        return new self(sprintf(
+            'You have specified both a "$routeIdentifierPlaceholder" value ("%s") and provided one for the'
+            . ' "%s" (resourceIdentifier) key of the $identifiersToPlaceholdersMapping" (with value "%s"),'
+            . ' creating a conflict. Set the correct value in the "$identifiersToPlaceholdersMapping",'
+            . ' and set the "$routeIdentifierPlaceholder" value to "id" to correct the issue.',
+            $routeIdentifierPlaceholder,
+            $resourceIdentifier,
+            $routeIdentifierPlaceholderFromMapping
+        ));
+    }
 }

--- a/src/Metadata/RouteBasedResourceMetadata.php
+++ b/src/Metadata/RouteBasedResourceMetadata.php
@@ -48,6 +48,17 @@ class RouteBasedResourceMetadata extends AbstractResourceMetadata
         $this->resourceIdentifier = $resourceIdentifier;
         $this->routeIdentifierPlaceholder = $routeIdentifierPlaceholder;
 
+        if (array_key_exists($resourceIdentifier, $identifiersToPlaceholdersMapping)
+            && $routeIdentifierPlaceholder !== self::DEFAULT_ROUTE_ID_PLACEHOLDER
+            && $identifiersToPlaceholdersMapping[$resourceIdentifier] !== $routeIdentifierPlaceholder
+        ) {
+            throw Exception\InvalidConfigException::dueToConflictingRouteIdentifierPlaceholder(
+                $resourceIdentifier,
+                $routeIdentifierPlaceholder,
+                $identifiersToPlaceholdersMapping[$resourceIdentifier]
+            );
+        }
+
         if (! array_key_exists($resourceIdentifier, $identifiersToPlaceholdersMapping)) {
             $identifiersToPlaceholdersMapping[$resourceIdentifier] = $routeIdentifierPlaceholder;
         }

--- a/src/Metadata/RouteBasedResourceMetadata.php
+++ b/src/Metadata/RouteBasedResourceMetadata.php
@@ -10,6 +10,9 @@ namespace Mezzio\Hal\Metadata;
 
 class RouteBasedResourceMetadata extends AbstractResourceMetadata
 {
+    private const DEFAULT_RESOURCE_ID = 'id';
+    private const DEFAULT_ROUTE_ID_PLACEHOLDER = 'id';
+
     /** @var array */
     private $identifiersToPlaceHoldersMapping;
 
@@ -25,21 +28,30 @@ class RouteBasedResourceMetadata extends AbstractResourceMetadata
     /** @var array */
     private $routeParams;
 
+    /**
+     * @param string $routeIdentifierPlaceholder Deprecated; use $identifiersToPlaceholdersMapping instead.
+     */
     public function __construct(
         string $class,
         string $route,
         string $extractor,
-        string $resourceIdentifier = 'id',
-        string $routeIdentifierPlaceholder = 'id',
+        string $resourceIdentifier = self::DEFAULT_RESOURCE_ID,
+        string $routeIdentifierPlaceholder = self::DEFAULT_ROUTE_ID_PLACEHOLDER,
         array $routeParams = [],
-        array $identifiersToPlaceholdersMapping = ['id' => 'id']
+        array $identifiersToPlaceholdersMapping = []
     ) {
         $this->class = $class;
         $this->route = $route;
         $this->extractor = $extractor;
+        $this->routeParams = $routeParams;
+
         $this->resourceIdentifier = $resourceIdentifier;
         $this->routeIdentifierPlaceholder = $routeIdentifierPlaceholder;
-        $this->routeParams = $routeParams;
+
+        if (! array_key_exists($resourceIdentifier, $identifiersToPlaceholdersMapping)) {
+            $identifiersToPlaceholdersMapping[$resourceIdentifier] = $routeIdentifierPlaceholder;
+        }
+
         $this->identifiersToPlaceHoldersMapping = $identifiersToPlaceholdersMapping;
     }
 

--- a/src/Metadata/RouteBasedResourceMetadata.php
+++ b/src/Metadata/RouteBasedResourceMetadata.php
@@ -10,6 +10,9 @@ namespace Mezzio\Hal\Metadata;
 
 class RouteBasedResourceMetadata extends AbstractResourceMetadata
 {
+    /** @var array */
+    private $identifiersToPlaceHoldersMapping;
+
     /** @var string */
     private $resourceIdentifier;
 
@@ -28,7 +31,8 @@ class RouteBasedResourceMetadata extends AbstractResourceMetadata
         string $extractor,
         string $resourceIdentifier = 'id',
         string $routeIdentifierPlaceholder = 'id',
-        array $routeParams = []
+        array $routeParams = [],
+        array $identifiersToPlaceholdersMapping = ['id' => 'id']
     ) {
         $this->class = $class;
         $this->route = $route;
@@ -36,6 +40,7 @@ class RouteBasedResourceMetadata extends AbstractResourceMetadata
         $this->resourceIdentifier = $resourceIdentifier;
         $this->routeIdentifierPlaceholder = $routeIdentifierPlaceholder;
         $this->routeParams = $routeParams;
+        $this->identifiersToPlaceHoldersMapping = $identifiersToPlaceholdersMapping;
     }
 
     public function getRoute() : string
@@ -43,11 +48,26 @@ class RouteBasedResourceMetadata extends AbstractResourceMetadata
         return $this->route;
     }
 
+    public function getIdentifiersToPlaceholdersMapping() : array
+    {
+        return $this->identifiersToPlaceHoldersMapping;
+    }
+
+    /**
+     * This method has been kept for BC and should be deprecated.
+     *
+     * @return string
+     */
     public function getResourceIdentifier() : string
     {
         return $this->resourceIdentifier;
     }
 
+    /**
+     * This method has been kept for BC and should be deprecated.
+     *
+     * @return string
+     */
     public function getRouteIdentifierPlaceholder() : string
     {
         return $this->routeIdentifierPlaceholder;

--- a/src/Metadata/RouteBasedResourceMetadataFactory.php
+++ b/src/Metadata/RouteBasedResourceMetadataFactory.php
@@ -73,7 +73,8 @@ class RouteBasedResourceMetadataFactory implements MetadataFactoryInterface
             $metadata['extractor'],
             $metadata['resource_identifier'] ?? 'id',
             $metadata['route_identifier_placeholder'] ?? 'id',
-            $metadata['route_params'] ?? []
+            $metadata['route_params'] ?? [],
+            $metadata['identifiers_to_placeholders_mapping'] ?? ['id' => 'id']
         );
     }
 }

--- a/src/Metadata/RouteBasedResourceMetadataFactory.php
+++ b/src/Metadata/RouteBasedResourceMetadataFactory.php
@@ -41,6 +41,8 @@ class RouteBasedResourceMetadataFactory implements MetadataFactoryInterface
      *
      *          // What placeholder in the route string represents the resource
      *          // identifier. Defaults to "id".
+     *          // Deprecated since 1.4.0; use the 'identifiers_to_placeholders_mapping'
+     *          // setting instead.
      *          'route_identifier_placeholder' => 'id',
      *
      *          // An array of additional routing parameters to use when

--- a/src/Metadata/RouteBasedResourceMetadataFactory.php
+++ b/src/Metadata/RouteBasedResourceMetadataFactory.php
@@ -47,6 +47,12 @@ class RouteBasedResourceMetadataFactory implements MetadataFactoryInterface
      *          // generating the self relational link for the collection
      *          // resource. Defaults to an empty array.
      *          'route_params' => [],
+     *
+     *          // An array mapping resource properties to routing placeholder
+     *          // names. This can also be used to replace the
+     *          // 'route_identifier_placeholder' setting, which will be removed
+     *          // in version 2.0.
+     *          'identifiers_to_placeholders_mapping' => ['id' => 'id'],
      *     ]
      *     </code>
      * @return AbstractMetadata

--- a/src/ResourceGenerator/RouteBasedResourceStrategy.php
+++ b/src/ResourceGenerator/RouteBasedResourceStrategy.php
@@ -38,14 +38,7 @@ class RouteBasedResourceStrategy implements StrategyInterface
             $request
         );
 
-        $routeParams        = $metadata->getRouteParams();
-        $resourceIdentifier = $metadata->getResourceIdentifier();
-        $routeIdentifier    = $metadata->getRouteIdentifierPlaceholder();
-
-        if (isset($data[$resourceIdentifier])) {
-            $routeParams[$routeIdentifier] = $data[$resourceIdentifier];
-        }
-
+        $routeParams    = $metadata->getRouteParams();
         $placeholderMap = $metadata->getIdentifiersToPlaceholdersMapping();
 
         // Inject all scalar entity keys automatically into route parameters

--- a/src/ResourceGenerator/RouteBasedResourceStrategy.php
+++ b/src/ResourceGenerator/RouteBasedResourceStrategy.php
@@ -46,11 +46,20 @@ class RouteBasedResourceStrategy implements StrategyInterface
             $routeParams[$routeIdentifier] = $data[$resourceIdentifier];
         }
 
+        $placeholderMap = $metadata->getIdentifiersToPlaceholdersMapping();
+
         // Inject all scalar entity keys automatically into route parameters
         foreach ($data as $key => $value) {
-            if (is_scalar($value)) {
-                $routeParams[$key] = $value;
+            if (! is_scalar($value)) {
+                continue;
             }
+
+            if (array_key_exists($key, $placeholderMap)) {
+                $routeParams[$placeholderMap[$key]] = $value;
+                continue;
+            }
+
+            $routeParams[$key] = $value;
         }
 
         return new HalResource($data, [

--- a/test/Metadata/MetadataMapFactoryTest.php
+++ b/test/Metadata/MetadataMapFactoryTest.php
@@ -251,9 +251,6 @@ class MetadataMapFactoryTest extends TestCase
         $this->assertSame(Metadata\AbstractCollectionMetadata::TYPE_PLACEHOLDER, $metadata->getPaginationParamType());
     }
 
-    /**
-     *
-     */
     public function testFactoryCanMapRouteBasedResourceMetadata()
     {
         $this->container->has('config')->willReturn(true);
@@ -295,8 +292,9 @@ class MetadataMapFactoryTest extends TestCase
         $this->assertSame('foo_id', $metadata->getRouteIdentifierPlaceholder());
         $this->assertSame(['foo' => 'bar'], $metadata->getRouteParams());
         $this->assertSame([
-            'bar' => 'bar_value',
-            'baz' => 'baz_value',
+            'bar'    => 'bar_value',
+            'baz'    => 'baz_value',
+            'foo_id' => 'foo_id',
         ], $metadata->getIdentifiersToPlaceholdersMapping());
     }
 

--- a/test/Metadata/MetadataMapFactoryTest.php
+++ b/test/Metadata/MetadataMapFactoryTest.php
@@ -358,4 +358,38 @@ class MetadataMapFactoryTest extends TestCase
 
         $this->assertInstanceOf(TestAsset\TestMetadata::class, $metadata);
     }
+
+    public function testFactoryRaisesExceptionWhenCreatingRouteBasedResourceMetadataContainingConfigConflicts()
+    {
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn(
+            [
+                MetadataMap::class => [
+                    [
+                        '__class__'                    => RouteBasedResourceMetadata::class,
+                        'resource_class'               => stdClass::class,
+                        'route'                        => 'foo',
+                        'extractor'                    => 'ObjectProperty',
+                        'resource_identifier'          => 'foo_id',
+                        'route_identifier_placeholder' => 'foo_id',
+                        'route_params'                 => ['foo' => 'bar'],
+                        'identifiers_to_placeholders_mapping' => [
+                            'foo_id' => 'id',
+                            'bar'    => 'bar_value',
+                            'baz'    => 'baz_value',
+                        ],
+                    ],
+                ],
+                'mezzio-hal' => [
+                    'metadata-factories' => [
+                        RouteBasedResourceMetadata::class => RouteBasedResourceMetadataFactory::class,
+                    ],
+                ],
+            ]
+        );
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage('"$routeIdentifierPlaceholder"');
+        ($this->factory)($this->container->reveal());
+    }
 }

--- a/test/Metadata/MetadataMapFactoryTest.php
+++ b/test/Metadata/MetadataMapFactoryTest.php
@@ -268,6 +268,10 @@ class MetadataMapFactoryTest extends TestCase
                         'resource_identifier'          => 'foo_id',
                         'route_identifier_placeholder' => 'foo_id',
                         'route_params'                 => ['foo' => 'bar'],
+                        'identifiers_to_placeholders_mapping' => [
+                            'bar' => 'bar_value',
+                            'baz' => 'baz_value',
+                        ],
                     ],
                 ],
                 'mezzio-hal' => [
@@ -290,6 +294,10 @@ class MetadataMapFactoryTest extends TestCase
         $this->assertSame('foo_id', $metadata->getResourceIdentifier());
         $this->assertSame('foo_id', $metadata->getRouteIdentifierPlaceholder());
         $this->assertSame(['foo' => 'bar'], $metadata->getRouteParams());
+        $this->assertSame([
+            'bar' => 'bar_value',
+            'baz' => 'baz_value',
+        ], $metadata->getIdentifiersToPlaceholdersMapping());
     }
 
     public function testFactoryCanMapRouteBasedCollectionMetadata()

--- a/test/ResourceGeneratorTest.php
+++ b/test/ResourceGeneratorTest.php
@@ -796,7 +796,6 @@ class ResourceGeneratorTest extends TestCase
                 'foo-bar',
                 [
                     'foo_bar_id' => 'XXXX-YYYY-ZZZZ',
-                    'id'         => 'XXXX-YYYY-ZZZZ',
                     'foo'        => 'BAR',
                     'test'       => 'param',
                 ]
@@ -845,10 +844,6 @@ class ResourceGeneratorTest extends TestCase
                 'foo-bar',
                 [
                     'foo_bar_id' => 'XXXX-YYYY-ZZZZ',
-                    // This will still be present until we can remove the
-                    // $routeIdentifierPlaceholder from
-                    // RouteBasedResourceMetadata::__construct
-                    'id'         => 'XXXX-YYYY-ZZZZ',
                     'foo_value'  => 'BAR',
                     'bar_value'  => 'BAZ',
                 ]


### PR DESCRIPTION
Signed-off-by: Corentin Larose <corentin.larose@gmail.com>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | yes
| QA            | no

### Description

Let's say I have an applicant table, a skill table and a N:M relationship table to list applicant's skills.

Let's say I have a REST API with these routes:

Read applicants collection: /api/rest/v1/applicants^GET
Read applicant entity: /api/rest/v1/applicants/{id}^GET

Read skills collection: /api/rest/v1/skills^GET
Read skill entity: /api/rest/v1/skills/{id}^GET

Read an applicant's skills collection: /api/rest/v1/applicants/{applicant_id}/skills^GET
Read an applicant's skill entity: /api/rest/v1/applicants/{id0}/skills/{id1}^GET

For this last case, in my metadatamap, I can't use `resource_identifier`, `route_identifier_placeholder` options twice  to map my entity properties to the route palceholder.

I propose to add the possibility of mapping an arbitrary number of entity properties to palceholders.

Settings would look like this in MetadataMap:
```php
        [
            'identifiers_to_placeholders_mapping' => [
                'applicant_id' => 'id0',
                'skill_id' => 'id1',
            ],
            '__class__' => RouteBasedResourceMetadata::class,
            'extractor' => ObjectPropertyHydrator::class,
            'resource_class' => ApplicantSkillEntity::class,
            'route' => '/api/rest/v1/applicants/{id0}/skills/{id1}^GET',
        ],
```

If principle is accepted I will provide documentation and UTs, we could also drepeciate the older way.