### PR TITLE
Make all entity keys available as route parameters

### DIFF
--- a/src/ResourceGenerator/RouteBasedResourceStrategy.php
+++ b/src/ResourceGenerator/RouteBasedResourceStrategy.php
@@ -45,6 +45,11 @@ class RouteBasedResourceStrategy implements StrategyInterface
         if (isset($data[$resourceIdentifier])) {
             $routeParams[$routeIdentifier] = $data[$resourceIdentifier];
         }
+        
+        // Inject all entity keys automatically into route parameters
+        foreach($data as $key => $value) {
+            $routeParams[$key] = $value;
+        }
 
         return new HalResource($data, [
             $resourceGenerator->getLinkGenerator()->fromRoute(


### PR DESCRIPTION
As discussed in https://github.com/mezzio/mezzio-hal/issues/14 I would like to request my bugfix to the master branch.

This fix helps you to automatically replace place holders in your route by entity keys.

`$app->post('/api/clients/{clientId:\d+}/users/{userId:\d+}/uploads/{id:\d+}', []);`

Normally, only 'id' will be replaced and clientId and userId not. In that case you get an exception. If you use my fix automatically 'clientId' and 'userId' will be filled out when they are available as parameters.