### PR TITLE
Make all entity keys available as route parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 Versions prior to 0.4.0 were released as the package "weierophinney/hal".
 
-## 1.3.2 - TBD
+## 1.4.0 - TBD
 
 ### Added
 
@@ -12,7 +12,7 @@ Versions prior to 0.4.0 were released as the package "weierophinney/hal".
 
 ### Changed
 
-- Nothing.
+- [#16](https://github.com/mezzio/mezzio-hal/pull/16) changes the behavior when route-based resource links are generated. It now passes all scalar properties of the resource as route parameters, allowing the resource to fill in properties required by the route, without the need of seeding metadata. As an example, if you defined the route `/group/:group_id/:user_id`, and `:user_id` is the resource identifier, and your resource also defines `group_id`, the `group_id` value will fill in the associated value in the generated URI.
 
 ### Deprecated
 
@@ -136,28 +136,6 @@ Versions prior to 0.4.0 were released as the package "weierophinney/hal".
 
 - [zendframework/zend-expressive-hal#39](https://github.com/zendframework/zend-expressive-hal/pull/39) updates `ResourceGeneratorFactory` to allow passing an alternate service name to use when
   retrieving the `LinkGenerator` dependency.
-
-### Deprecated
-
-- Nothing.
-
-### Removed
-
-- Nothing.
-
-### Fixed
-
-- Nothing.
-
-## 1.0.3 - TBD
-
-### Added
-
-- Nothing.
-
-### Changed
-
-- Nothing.
 
 ### Deprecated
 

--- a/src/ResourceGenerator/RouteBasedResourceStrategy.php
+++ b/src/ResourceGenerator/RouteBasedResourceStrategy.php
@@ -46,6 +46,11 @@ class RouteBasedResourceStrategy implements StrategyInterface
             $routeParams[$routeIdentifier] = $data[$resourceIdentifier];
         }
 
+        // Inject all entity keys automatically into route parameters
+        foreach ($data as $key => $value) {
+            $routeParams[$key] = $value;
+        }
+
         return new HalResource($data, [
             $resourceGenerator->getLinkGenerator()->fromRoute(
                 'self',

--- a/src/ResourceGenerator/RouteBasedResourceStrategy.php
+++ b/src/ResourceGenerator/RouteBasedResourceStrategy.php
@@ -46,9 +46,11 @@ class RouteBasedResourceStrategy implements StrategyInterface
             $routeParams[$routeIdentifier] = $data[$resourceIdentifier];
         }
 
-        // Inject all entity keys automatically into route parameters
+        // Inject all scalar entity keys automatically into route parameters
         foreach ($data as $key => $value) {
-            $routeParams[$key] = $value;
+            if (is_scalar($value)) {
+                $routeParams[$key] = $value;
+            }
         }
 
         return new HalResource($data, [

--- a/src/ResourceGenerator/RouteBasedResourceStrategy.php
+++ b/src/ResourceGenerator/RouteBasedResourceStrategy.php
@@ -45,6 +45,11 @@ class RouteBasedResourceStrategy implements StrategyInterface
         if (isset($data[$resourceIdentifier])) {
             $routeParams[$routeIdentifier] = $data[$resourceIdentifier];
         }
+        
+        // Inject all entity keys automatically into route parameters
+        foreach($data as $key => $value) {
+            $routeParams[$key] = $value;
+        }
 
         return new HalResource($data, [
             $resourceGenerator->getLinkGenerator()->fromRoute(

--- a/test/ResourceGenerator/NestedCollectionResourceGenerationTest.php
+++ b/test/ResourceGenerator/NestedCollectionResourceGenerationTest.php
@@ -18,6 +18,7 @@ use Mezzio\Hal\ResourceGenerator;
 use MezzioTest\Hal\Assertions;
 use MezzioTest\Hal\TestAsset;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -136,7 +137,10 @@ class NestedCollectionResourceGenerationTest extends TestCase
                 'self',
                 $request->reveal(),
                 'foo-bar',
-                [ 'id' => 101010 ]
+                Argument::that(function (array $params) {
+                    return array_key_exists('id', $params)
+                        && $params['id'] === 101010;
+                })
             )
             ->willReturn(new Link('self', '/api/foo-bar/1234'));
 
@@ -146,7 +150,10 @@ class NestedCollectionResourceGenerationTest extends TestCase
                     'self',
                     $request->reveal(),
                     'child',
-                    [ 'id' => $i ]
+                    Argument::that(function (array $params) use ($i) {
+                        return array_key_exists('id', $params)
+                            && $params['id'] === $i;
+                    })
                 )
                 ->willReturn(new Link('self', '/api/child/' . $i));
         }
@@ -157,7 +164,7 @@ class NestedCollectionResourceGenerationTest extends TestCase
                 $request->reveal(),
                 'collection',
                 [],
-                []
+                Argument::type('array')
             )
             ->willReturn(new Link('self', '/api/collection'));
 

--- a/test/ResourceGenerator/ResourceWithNestedInstancesTest.php
+++ b/test/ResourceGenerator/ResourceWithNestedInstancesTest.php
@@ -18,6 +18,7 @@ use Mezzio\Hal\ResourceGenerator;
 use MezzioTest\Hal\Assertions;
 use MezzioTest\Hal\TestAsset;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -101,7 +102,10 @@ class ResourceWithNestedInstancesTest extends TestCase
                 'self',
                 $request->reveal(),
                 'foo-bar',
-                [ 'id' => 1234 ]
+                Argument::that(function (array $params) {
+                    return array_key_exists('id', $params)
+                        && $params['id'] === 1234;
+                })
             )
             ->willReturn(new Link('self', '/api/foo-bar/1234'));
 
@@ -110,7 +114,10 @@ class ResourceWithNestedInstancesTest extends TestCase
                 'self',
                 $request->reveal(),
                 'child',
-                [ 'id' => 9876 ]
+                Argument::that(function (array $params) {
+                    return array_key_exists('id', $params)
+                        && $params['id'] === 9876;
+                })
             )
             ->willReturn(new Link('self', '/api/child/9876'));
 

--- a/test/ResourceGenerator/RouteBasedCollectionWithRouteParamsTest.php
+++ b/test/ResourceGenerator/RouteBasedCollectionWithRouteParamsTest.php
@@ -20,6 +20,7 @@ use Mezzio\Hal\ResourceGenerator;
 use MezzioTest\Hal\Assertions;
 use MezzioTest\Hal\TestAsset;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -194,7 +195,12 @@ class RouteBasedCollectionWithRouteParamsTest extends TestCase
             $rel,
             $request->reveal(),
             'foo-bar',
-            ['foo_id' => 1234, 'p' => $page],
+            Argument::that(function (array $params) use ($page) {
+                return array_key_exists('foo_id', $params)
+                    && array_key_exists('p', $params)
+                    && $params['foo_id'] === 1234
+                    && $params['p'] === $page;
+            }),
             ['sort' => 'ASC']
         )->willReturn(new Link($rel, sprintf('/api/foo/1234/p/%d?sort=ASC', $page)));
     }
@@ -216,10 +222,12 @@ class RouteBasedCollectionWithRouteParamsTest extends TestCase
                     'self',
                     $request->reveal(),
                     'foo-bar',
-                    [
-                        'foo_id' => 1234,
-                        'bar_id' => $i,
-                    ]
+                    Argument::that(function (array $params) use ($i) {
+                        return array_key_exists('foo_id', $params)
+                            && array_key_exists('bar_id', $params)
+                            && $params['foo_id'] === 1234
+                            && $params['bar_id'] === $i;
+                    })
                 )
                 ->willReturn(new Link('self', '/api/foo/1234/bar/' . $i));
         }

--- a/test/ResourceGenerator/UrlBasedCollectionWithRouteParamsTest.php
+++ b/test/ResourceGenerator/UrlBasedCollectionWithRouteParamsTest.php
@@ -20,6 +20,7 @@ use Mezzio\Hal\ResourceGenerator;
 use MezzioTest\Hal\Assertions;
 use MezzioTest\Hal\TestAsset;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -183,10 +184,12 @@ class UrlBasedCollectionWithRouteParamsTest extends TestCase
                     'self',
                     $request->reveal(),
                     'foo-bar',
-                    [
-                        'foo_id' => 1234,
-                        'bar_id' => $i,
-                    ]
+                    Argument::that(function (array $params) use ($i) {
+                        return array_key_exists('foo_id', $params)
+                            && array_key_exists('bar_id', $params)
+                            && $params['foo_id'] === 1234
+                            && $params['bar_id'] === $i;
+                    })
                 )
                 ->willReturn(new Link('self', '/api/foo/1234/bar/' . $i));
         }

--- a/test/ResourceGeneratorTest.php
+++ b/test/ResourceGeneratorTest.php
@@ -23,6 +23,7 @@ use Mezzio\Hal\ResourceGenerator;
 use Mezzio\Hal\ResourceGenerator\Exception\OutOfBoundsException;
 use MezzioTest\Hal\TestAsset\TestMetadata;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -173,10 +174,12 @@ class ResourceGeneratorTest extends TestCase
                 'self',
                 $this->request->reveal(),
                 'foo-bar',
-                [
-                    'foo_bar_id' => 'XXXX-YYYY-ZZZZ',
-                    'test' => 'param',
-                ]
+                Argument::that(function (array $params) {
+                    return array_key_exists('foo_bar_id', $params)
+                        && array_key_exists('test', $params)
+                        && $params['foo_bar_id'] === 'XXXX-YYYY-ZZZZ'
+                        && $params['test'] === 'param';
+                })
             )
             ->willReturn(new Link('self', '/api/foo-bar/XXXX-YYYY-ZZZZ'));
 
@@ -289,10 +292,12 @@ class ResourceGeneratorTest extends TestCase
                     'self',
                     $this->request->reveal(),
                     'foo-bar',
-                    [
-                        'foo_bar_id' => $i,
-                        'test' => 'param',
-                    ]
+                    Argument::that(function (array $params) use ($i) {
+                        return array_key_exists('foo_bar_id', $params)
+                            && array_key_exists('test', $params)
+                            && $params['foo_bar_id'] === $i
+                            && $params['test'] === 'param';
+                    })
                 )
                 ->willReturn(new Link('self', '/api/foo-bar/' . $i));
         }
@@ -311,7 +316,7 @@ class ResourceGeneratorTest extends TestCase
                 'self',
                 $this->request->reveal(),
                 'foo-bar',
-                [],
+                Argument::type('array'),
                 ['page' => 3]
             )
             ->willReturn(new Link('self', '/api/foo-bar?page=3'));
@@ -320,7 +325,7 @@ class ResourceGeneratorTest extends TestCase
                 'first',
                 $this->request->reveal(),
                 'foo-bar',
-                [],
+                Argument::type('array'),
                 ['page' => 1]
             )
             ->willReturn(new Link('first', '/api/foo-bar?page=1'));
@@ -329,7 +334,7 @@ class ResourceGeneratorTest extends TestCase
                 'prev',
                 $this->request->reveal(),
                 'foo-bar',
-                [],
+                Argument::type('array'),
                 ['page' => 2]
             )
             ->willReturn(new Link('prev', '/api/foo-bar?page=2'));
@@ -338,7 +343,7 @@ class ResourceGeneratorTest extends TestCase
                 'next',
                 $this->request->reveal(),
                 'foo-bar',
-                [],
+                Argument::type('array'),
                 ['page' => 4]
             )
             ->willReturn(new Link('next', '/api/foo-bar?page=4'));
@@ -347,7 +352,7 @@ class ResourceGeneratorTest extends TestCase
                 'last',
                 $this->request->reveal(),
                 'foo-bar',
-                [],
+                Argument::type('array'),
                 ['page' => 5]
             )
             ->willReturn(new Link('last', '/api/foo-bar?page=5'));
@@ -419,10 +424,12 @@ class ResourceGeneratorTest extends TestCase
                     'self',
                     $this->request->reveal(),
                     'foo-bar',
-                    [
-                        'foo_bar_id' => $i,
-                        'test' => 'param',
-                    ]
+                    Argument::that(function (array $params) use ($i) {
+                        return array_key_exists('foo_bar_id', $params)
+                            && array_key_exists('test', $params)
+                            && $params['foo_bar_id'] === $i
+                            && $params['test'] === 'param';
+                    })
                 )
                 ->willReturn(new Link('self', '/api/foo-bar/' . $i));
         }
@@ -441,7 +448,7 @@ class ResourceGeneratorTest extends TestCase
                 'self',
                 $this->request->reveal(),
                 'foo-bar',
-                [],
+                Argument::type('array'),
                 ['page' => 3]
             )
             ->willReturn(new Link('self', '/api/foo-bar?page=3'));
@@ -450,7 +457,7 @@ class ResourceGeneratorTest extends TestCase
                 'first',
                 $this->request->reveal(),
                 'foo-bar',
-                [],
+                Argument::type('array'),
                 ['page' => 1]
             )
             ->willReturn(new Link('first', '/api/foo-bar?page=1'));
@@ -459,7 +466,7 @@ class ResourceGeneratorTest extends TestCase
                 'prev',
                 $this->request->reveal(),
                 'foo-bar',
-                [],
+                Argument::type('array'),
                 ['page' => 2]
             )
             ->willReturn(new Link('prev', '/api/foo-bar?page=2'));
@@ -468,7 +475,7 @@ class ResourceGeneratorTest extends TestCase
                 'next',
                 $this->request->reveal(),
                 'foo-bar',
-                [],
+                Argument::type('array'),
                 ['page' => 4]
             )
             ->willReturn(new Link('next', '/api/foo-bar?page=4'));
@@ -477,7 +484,7 @@ class ResourceGeneratorTest extends TestCase
                 'last',
                 $this->request->reveal(),
                 'foo-bar',
-                [],
+                Argument::type('array'),
                 ['page' => 5]
             )
             ->willReturn(new Link('last', '/api/foo-bar?page=5'));


### PR DESCRIPTION
If you have more than one place holder in your route, this fix will automatically replace the other place holders, too.

Signed-off-by: arstom <spambar@web.de>

On branch route-fix
 Changes to be committed:
	modified:   src/ResourceGenerator/RouteBasedResourceStrategy.php