### PR TITLE
PHP 8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:
@@ -15,23 +14,29 @@ matrix:
     - php: 7.3
       env:
         - DEPS=lowest
+        - COMPOSER_ARGS="--no-interaction"
     - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
+        - COMPOSER_ARGS="--no-interaction"
     - php: 7.4
       env:
         - DEPS=lowest
+        - COMPOSER_ARGS="--no-interaction"
     - php: 7.4
       env:
         - DEPS=latest
+        - COMPOSER_ARGS="--no-interaction"
     - php: 8.0
       env:
         - DEPS=lowest
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
     - php: 8.0
       env:
         - DEPS=latest
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,30 +6,30 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction --no-plugins"
+    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=lowest
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=latest
-    - php: 7.3
+    - php: 8.0
       env:
         - DEPS=lowest
-    - php: 7.3
+    - php: 8.0
       env:
         - DEPS=latest
 
@@ -45,7 +45,7 @@ install:
   - stty cols 120 && composer show
 
 script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then XDEBUG_MODE=coverage composer test-coverage ; else composer test ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
 
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -31,19 +31,20 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "psr/http-message": "^1.0.1",
         "psr/link": "^1.0",
-        "willdurand/negotiation": "^2.3.1"
+        "willdurand/negotiation": "^3.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2.6",
+        "doctrine/orm": "^2.8.1",
         "laminas/laminas-coding-standard": "~1.0.0",
-        "laminas/laminas-hydrator": "^2.3.1 || ^3.0",
-        "laminas/laminas-paginator": "^2.7",
-        "mezzio/mezzio-helpers": "^5.0.0alpha3",
-        "phpunit/phpunit": "^7.0.1"
+        "laminas/laminas-hydrator": "^3.2",
+        "laminas/laminas-paginator": "^2.9",
+        "mezzio/mezzio-helpers": "^5.4",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.5"
     },
     "provide": {
         "psr/link-implementation": "1.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,15 +3,14 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
-    <testsuites>
-        <testsuite name="mezzio-hal">
-            <directory>./test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="mezzio-hal">
+      <directory>./test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/ResourceGenerator/GenerateSelfLinkTrait.php
+++ b/src/ResourceGenerator/GenerateSelfLinkTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-hal for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-hal/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-hal/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Mezzio\Hal\ResourceGenerator;
+
+use Mezzio\Hal\Metadata\AbstractCollectionMetadata;
+use Mezzio\Hal\ResourceGenerator;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * This trait is intended to correct the difference in method signature
+ * from the trait linked below, and their implementations, since that difference
+ * now results in a fatal error in PHP 8.
+ *
+ * @see ExtractCollectionTrait::generateSelfLink
+ */
+trait GenerateSelfLinkTrait
+{
+    abstract protected function generateSelfLink(
+        AbstractCollectionMetadata $metadata,
+        ResourceGenerator $resourceGenerator,
+        ServerRequestInterface $request
+    );
+}

--- a/src/ResourceGenerator/RouteBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/RouteBasedCollectionStrategy.php
@@ -20,7 +20,9 @@ use function get_class;
 
 class RouteBasedCollectionStrategy implements StrategyInterface
 {
-    use ExtractCollectionTrait;
+    use ExtractCollectionTrait, GenerateSelfLinkTrait {
+        GenerateSelfLinkTrait::generateSelfLink insteadof ExtractCollectionTrait;
+    }
 
     public function createResource(
         $instance,

--- a/src/ResourceGenerator/UrlBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/UrlBasedCollectionStrategy.php
@@ -28,7 +28,9 @@ use const PHP_URL_QUERY;
 
 class UrlBasedCollectionStrategy implements StrategyInterface
 {
-    use ExtractCollectionTrait;
+    use ExtractCollectionTrait, GenerateSelfLinkTrait {
+        GenerateSelfLinkTrait::generateSelfLink insteadof ExtractCollectionTrait;
+    }
 
     public function createResource(
         $instance,

--- a/test/Assertions.php
+++ b/test/Assertions.php
@@ -35,7 +35,7 @@ trait Assertions
     public static function getLinkByRel(string $rel, HalResource $resource) : Link
     {
         $links = $resource->getLinksByRel($rel);
-        self::assertInternalType('array', $links, sprintf("Did not receive list of links for rel %s", $rel));
+        self::assertIsArray($links, sprintf("Did not receive list of links for rel %s", $rel));
         self::assertCount(1, $links, sprintf(
             'Received more links than expected (expected 1; received %d) for rel %s',
             count($links),

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -28,7 +28,7 @@ class ConfigProviderTest extends TestCase
     public function testInvocationReturnsArray() : array
     {
         $config = ($this->provider)();
-        self::assertInternalType('array', $config);
+        self::assertIsArray($config);
 
         return $config;
     }
@@ -40,6 +40,6 @@ class ConfigProviderTest extends TestCase
     {
         self::assertArrayHasKey('dependencies', $config);
         self::assertArrayHasKey('mezzio-hal', $config);
-        self::assertInternalType('array', $config['dependencies']);
+        self::assertIsArray($config['dependencies']);
     }
 }

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -39,7 +39,7 @@ class ExceptionTest extends TestCase
      */
     public function testExceptionIsInstanceOfExceptionInterface(string $exception) : void
     {
-        self::assertContains('Exception', $exception);
+        self::assertStringContainsString('Exception', $exception);
         self::assertTrue(is_a($exception, ExceptionInterface::class, true));
     }
 }

--- a/test/HalResponseFactoryFactoryTest.php
+++ b/test/HalResponseFactoryFactoryTest.php
@@ -15,12 +15,17 @@ use Mezzio\Hal\HalResponseFactoryFactory;
 use Mezzio\Hal\Renderer;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use ReflectionProperty;
 
 class HalResponseFactoryFactoryTest extends TestCase
 {
+    use PHPUnitDeprecatedAssertions;
+
+    use ProphecyTrait;
+
     public static function assertResponseFactoryReturns(ResponseInterface $expected, HalResponseFactory $factory) : void
     {
         $r = new ReflectionProperty($factory, 'responseFactory');

--- a/test/HalResponseFactoryTest.php
+++ b/test/HalResponseFactoryTest.php
@@ -12,6 +12,7 @@ use Mezzio\Hal\HalResponseFactory;
 use Mezzio\Hal\Renderer;
 use MezzioTest\Hal\Renderer\TestAsset;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
@@ -22,7 +23,9 @@ class HalResponseFactoryTest extends TestCase
 {
     use TestAsset;
 
-    public function setUp()
+    use ProphecyTrait;
+
+    public function setUp(): void
     {
         $this->request      = $this->prophesize(ServerRequestInterface::class);
         $this->response     = $this->prophesize(ResponseInterface::class);

--- a/test/LinkGenerator/MezzioUrlGeneratorFactoryTest.php
+++ b/test/LinkGenerator/MezzioUrlGeneratorFactoryTest.php
@@ -12,13 +12,19 @@ use Mezzio\Hal\LinkGenerator\MezzioUrlGenerator;
 use Mezzio\Hal\LinkGenerator\MezzioUrlGeneratorFactory;
 use Mezzio\Helper\ServerUrlHelper;
 use Mezzio\Helper\UrlHelper;
+use MezzioTest\Hal\PHPUnitDeprecatedAssertions;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
 
 class MezzioUrlGeneratorFactoryTest extends TestCase
 {
-    public function setUp()
+    use PHPUnitDeprecatedAssertions;
+
+    use ProphecyTrait;
+
+    public function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
     }

--- a/test/LinkGenerator/MezzioUrlGeneratorTest.php
+++ b/test/LinkGenerator/MezzioUrlGeneratorTest.php
@@ -11,13 +11,19 @@ namespace MezzioTest\Hal\LinkGenerator;
 use Mezzio\Hal\LinkGenerator\MezzioUrlGenerator;
 use Mezzio\Helper\ServerUrlHelper;
 use Mezzio\Helper\UrlHelper;
+use MezzioTest\Hal\PHPUnitDeprecatedAssertions;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 
 class MezzioUrlGeneratorTest extends TestCase
 {
+    use PHPUnitDeprecatedAssertions;
+
+    use ProphecyTrait;
+
     public function testCanGenerateUrlWithOnlyUrlHelper()
     {
         $urlHelper = $this->prophesize(UrlHelper::class);

--- a/test/LinkGeneratorFactoryTest.php
+++ b/test/LinkGeneratorFactoryTest.php
@@ -13,10 +13,15 @@ namespace MezzioTest\Hal;
 use Mezzio\Hal\LinkGenerator;
 use Mezzio\Hal\LinkGeneratorFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
 class LinkGeneratorFactoryTest extends TestCase
 {
+    use PHPUnitDeprecatedAssertions;
+
+    use ProphecyTrait;
+
     public function testReturnsLinkGeneratorInstance() : void
     {
         $urlGenerator = $this->prophesize(LinkGenerator\UrlGeneratorInterface::class)->reveal();

--- a/test/LinkGeneratorTest.php
+++ b/test/LinkGeneratorTest.php
@@ -11,10 +11,13 @@ namespace MezzioTest\Hal;
 use Mezzio\Hal\Link;
 use Mezzio\Hal\LinkGenerator;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ServerRequestInterface;
 
 class LinkGeneratorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testUsesComposedUrlGeneratorToGenerateHrefForLink()
     {
         $request = $this->prophesize(ServerRequestInterface::class)->reveal();

--- a/test/Metadata/ExceptionTest.php
+++ b/test/Metadata/ExceptionTest.php
@@ -45,7 +45,7 @@ class ExceptionTest extends TestCase
      */
     public function testExceptionIsInstanceOfExceptionInterface(string $exception) : void
     {
-        self::assertContains('Exception', $exception);
+        self::assertStringContainsString('Exception', $exception);
         self::assertTrue(is_a($exception, ExceptionInterface::class, true));
     }
 }

--- a/test/Metadata/MetadataMapFactoryTest.php
+++ b/test/Metadata/MetadataMapFactoryTest.php
@@ -21,14 +21,20 @@ use Mezzio\Hal\Metadata\UrlBasedCollectionMetadata;
 use Mezzio\Hal\Metadata\UrlBasedCollectionMetadataFactory;
 use Mezzio\Hal\Metadata\UrlBasedResourceMetadata;
 use Mezzio\Hal\Metadata\UrlBasedResourceMetadataFactory;
+use MezzioTest\Hal\PHPUnitDeprecatedAssertions;
 use MezzioTest\Hal\TestAsset;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use stdClass;
 
 class MetadataMapFactoryTest extends TestCase
 {
+    use PHPUnitDeprecatedAssertions;
+
+    use ProphecyTrait;
+
     /**
      * @var MetadataMapFactory
      */
@@ -39,7 +45,7 @@ class MetadataMapFactoryTest extends TestCase
      */
     private $container;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
         $this->factory = new MetadataMapFactory();

--- a/test/Metadata/MetadataMapTest.php
+++ b/test/Metadata/MetadataMapTest.php
@@ -10,9 +10,12 @@ namespace MezzioTest\Hal\Metadata;
 
 use Mezzio\Hal\Metadata;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class MetadataMapTest extends TestCase
 {
+    use ProphecyTrait;
+
     private $metadataClasses = [
         Metadata\AbstractMetadata::class,
         Metadata\AbstractCollectionMetadata::class,
@@ -23,7 +26,7 @@ class MetadataMapTest extends TestCase
         Metadata\UrlBasedResourceMetadata::class,
     ];
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->map = new Metadata\MetadataMap();
     }

--- a/test/PHPUnitDeprecatedAssertions.php
+++ b/test/PHPUnitDeprecatedAssertions.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace MezzioTest\Hal;
+
+use PHPUnit\Framework\Constraint\IsType;
+use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\ExpectationFailedException;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionObject;
+
+trait PHPUnitDeprecatedAssertions
+{
+    /**
+     * Asserts that a variable is of a given type.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/3369
+     */
+    public static function assertInternalType(string $expected, $actual, string $message = ''): void
+    {
+        static::assertThat(
+            $actual,
+            new IsType($expected),
+            $message
+        );
+    }
+
+    /**
+     * Asserts that a static attribute of a class or an attribute of an object
+     * is empty.
+     *
+     * @param object|string $haystackClassOrObject
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/3338
+     */
+    public static function assertAttributeEmpty(
+        string $haystackAttributeName,
+        $haystackClassOrObject,
+        string $message = ''
+    ): void {
+        static::assertEmpty(
+            static::readAttribute($haystackClassOrObject, $haystackAttributeName),
+            $message
+        );
+    }
+
+    /**
+     * Asserts that an attribute is of a given type.
+     *
+     * @param object|string $classOrObject
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/3338
+     */
+    public static function assertAttributeInstanceOf(
+        string $expected,
+        string $attributeName,
+        $classOrObject,
+        string $message = ''
+    ): void {
+        static::assertInstanceOf(
+            $expected,
+            static::readAttribute($classOrObject, $attributeName),
+            $message
+        );
+    }
+
+    /**
+     * Asserts that a variable and an attribute of an object have the same type
+     * and value.
+     *
+     * @param object|string $actualClassOrObject
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/3338
+     */
+    public static function assertAttributeSame(
+        $expected,
+        string $actualAttributeName,
+        $actualClassOrObject,
+        string $message = ''
+    ): void {
+        static::assertSame(
+            $expected,
+            static::readAttribute($actualClassOrObject, $actualAttributeName),
+            $message
+        );
+    }
+
+    /**
+     * Returns the value of an attribute of a class or an object.
+     * This also works for attributes that are declared protected or private.
+     *
+     * @param object|string $classOrObject
+     *
+     * @throws Exception
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/3338
+     */
+    public static function readAttribute($classOrObject, string $attributeName)
+    {
+        if (! self::isValidClassAttributeName($attributeName)) {
+            throw self::invalidArgument(2, 'valid attribute name');
+        }
+
+        if (\is_string($classOrObject)) {
+            if (! \class_exists($classOrObject)) {
+                throw self::invalidArgument(
+                    1,
+                    'class name'
+                );
+            }
+
+            return static::getStaticAttribute(
+                $classOrObject,
+                $attributeName
+            );
+        }
+
+        if (\is_object($classOrObject)) {
+            return static::getObjectAttribute(
+                $classOrObject,
+                $attributeName
+            );
+        }
+
+        throw self::invalidArgument(
+            1,
+            'class name or object'
+        );
+    }
+
+    /**
+     * Returns the value of a static attribute.
+     * This also works for attributes that are declared protected or private.
+     *
+     * @throws Exception
+     * @throws ReflectionException
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/3338
+     */
+    public static function getStaticAttribute(string $className, string $attributeName)
+    {
+        if (! \class_exists($className)) {
+            throw self::invalidArgument(1, 'class name');
+        }
+
+        if (! self::isValidClassAttributeName($attributeName)) {
+            throw self::invalidArgument(2, 'valid attribute name');
+        }
+
+        $class = new ReflectionClass($className);
+
+        while ($class) {
+            $attributes = $class->getStaticProperties();
+
+            if (\array_key_exists($attributeName, $attributes)) {
+                return $attributes[$attributeName];
+            }
+
+            $class = $class->getParentClass();
+        }
+
+        throw new Exception(
+            \sprintf(
+                'Attribute "%s" not found in class.',
+                $attributeName
+            )
+        );
+    }
+
+    /**
+     * Returns the value of an object's attribute.
+     * This also works for attributes that are declared protected or private.
+     *
+     * @param object $object
+     *
+     * @throws Exception
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/3338
+     */
+    public static function getObjectAttribute($object, string $attributeName)
+    {
+        if (! \is_object($object)) {
+            throw self::invalidArgument(1, 'object');
+        }
+
+        if (! self::isValidClassAttributeName($attributeName)) {
+            throw self::invalidArgument(2, 'valid attribute name');
+        }
+
+        try {
+            $reflector = new ReflectionObject($object);
+
+            do {
+                try {
+                    $attribute = $reflector->getProperty($attributeName);
+
+                    if (! $attribute || $attribute->isPublic()) {
+                        return $object->$attributeName;
+                    }
+
+                    $attribute->setAccessible(true);
+                    $value = $attribute->getValue($object);
+                    $attribute->setAccessible(false);
+
+                    return $value;
+                } catch (ReflectionException $e) {
+                }
+            } while ($reflector = $reflector->getParentClass());
+        } catch (ReflectionException $e) {
+        }
+
+        throw new Exception(
+            \sprintf(
+                'Attribute "%s" not found in object.',
+                $attributeName
+            )
+        );
+    }
+
+    private static function isValidClassAttributeName(string $attributeName): bool
+    {
+        return \preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName);
+    }
+
+    private static function invalidArgument(int $argument, string $type, $value = null): Exception
+    {
+        $stack = \debug_backtrace();
+
+        return new Exception(
+            \sprintf(
+                'Argument #%d%sof %s::%s() must be a %s',
+                $argument,
+                $value !== null ? ' (' . \gettype($value) . '#' . $value . ')' : ' (No Value) ',
+                $stack[1]['class'],
+                $stack[1]['function'],
+                $type
+            )
+        );
+    }
+}

--- a/test/Renderer/XmlRendererTest.php
+++ b/test/Renderer/XmlRendererTest.php
@@ -80,7 +80,7 @@ EOX;
 
         $renderer = new XmlRenderer();
         $xml = $renderer->render($resource);
-        $this->assertContains($dateTime->format('c'), $xml);
+        $this->assertStringContainsString($dateTime->format('c'), $xml);
     }
 
     public function testCanRenderObjectsThatImplementToString()
@@ -94,7 +94,7 @@ EOX;
 
         $renderer = new XmlRenderer();
         $xml = $renderer->render($resource);
-        $this->assertContains((string) $instance, $xml);
+        $this->assertStringContainsString((string) $instance, $xml);
     }
 
     public function testRendersNullValuesAsTagsWithNoContent()
@@ -106,6 +106,6 @@ EOX;
 
         $renderer = new XmlRenderer();
         $xml = $renderer->render($resource);
-        $this->assertContains('<key/>', $xml);
+        $this->assertStringContainsString('<key/>', $xml);
     }
 }

--- a/test/ResourceGenerator/DoctrinePaginatorTest.php
+++ b/test/ResourceGenerator/DoctrinePaginatorTest.php
@@ -21,11 +21,14 @@ use Mezzio\Hal\ResourceGenerator\Exception\OutOfBoundsException;
 use Mezzio\Hal\ResourceGenerator\RouteBasedCollectionStrategy;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ServerRequestInterface;
 
 class DoctrinePaginatorTest extends TestCase
 {
-    public function setUp()
+    use ProphecyTrait;
+
+    public function setUp(): void
     {
         $this->metadata      = $this->prophesize(RouteBasedCollectionMetadata::class);
         $this->linkGenerator = $this->prophesize(LinkGenerator::class);

--- a/test/ResourceGenerator/ExceptionTest.php
+++ b/test/ResourceGenerator/ExceptionTest.php
@@ -45,7 +45,7 @@ class ExceptionTest extends TestCase
      */
     public function testExceptionIsInstanceOfExceptionInterface(string $exception) : void
     {
-        self::assertContains('Exception', $exception);
+        self::assertStringContainsString('Exception', $exception);
         self::assertTrue(is_a($exception, ExceptionInterface::class, true));
     }
 }

--- a/test/ResourceGenerator/NestedCollectionResourceGenerationTest.php
+++ b/test/ResourceGenerator/NestedCollectionResourceGenerationTest.php
@@ -16,8 +16,10 @@ use Mezzio\Hal\Metadata\RouteBasedCollectionMetadata;
 use Mezzio\Hal\Metadata\RouteBasedResourceMetadata;
 use Mezzio\Hal\ResourceGenerator;
 use MezzioTest\Hal\Assertions;
+use MezzioTest\Hal\PHPUnitDeprecatedAssertions;
 use MezzioTest\Hal\TestAsset;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -26,6 +28,10 @@ use function array_shift;
 class NestedCollectionResourceGenerationTest extends TestCase
 {
     use Assertions;
+
+    use PHPUnitDeprecatedAssertions;
+
+    use ProphecyTrait;
 
     public function testNestedCollectionIsEmbeddedAsAnArrayNotAHalCollection()
     {
@@ -68,7 +74,7 @@ class NestedCollectionResourceGenerationTest extends TestCase
             $this->assertInternalType('array', $selfLinks);
             $this->assertNotEmpty($selfLinks);
             $selfLink = array_shift($selfLinks);
-            $this->assertContains('/child/', $selfLink->getHref());
+            $this->assertStringContainsString('/child/', $selfLink->getHref());
         }
     }
 

--- a/test/ResourceGenerator/ResourceWithNestedInstancesTest.php
+++ b/test/ResourceGenerator/ResourceWithNestedInstancesTest.php
@@ -18,12 +18,15 @@ use Mezzio\Hal\ResourceGenerator;
 use MezzioTest\Hal\Assertions;
 use MezzioTest\Hal\TestAsset;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class ResourceWithNestedInstancesTest extends TestCase
 {
     use Assertions;
+
+    use ProphecyTrait;
 
     public function testNestedObjectInMetadataMapIsEmbeddedAsResource()
     {

--- a/test/ResourceGenerator/RouteBasedCollectionWithRouteParamsTest.php
+++ b/test/ResourceGenerator/RouteBasedCollectionWithRouteParamsTest.php
@@ -20,6 +20,7 @@ use Mezzio\Hal\ResourceGenerator;
 use MezzioTest\Hal\Assertions;
 use MezzioTest\Hal\TestAsset;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -28,6 +29,8 @@ use function sprintf;
 class RouteBasedCollectionWithRouteParamsTest extends TestCase
 {
     use Assertions;
+
+    use ProphecyTrait;
 
     public function testUsesRouteParamsAndQueriesWithPaginatorSpecifiedInMetadataWhenGeneratingLinkHref()
     {

--- a/test/ResourceGenerator/UrlBasedCollectionWithRouteParamsTest.php
+++ b/test/ResourceGenerator/UrlBasedCollectionWithRouteParamsTest.php
@@ -20,12 +20,15 @@ use Mezzio\Hal\ResourceGenerator;
 use MezzioTest\Hal\Assertions;
 use MezzioTest\Hal\TestAsset;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class UrlBasedCollectionWithRouteParamsTest extends TestCase
 {
     use Assertions;
+
+    use ProphecyTrait;
 
     public function testUsesQueriesWithPaginatorSpecifiedInMetadataWhenGeneratingLinkHref()
     {

--- a/test/ResourceGeneratorFactoryTest.php
+++ b/test/ResourceGeneratorFactoryTest.php
@@ -17,18 +17,23 @@ use Mezzio\Hal\ResourceGenerator;
 use Mezzio\Hal\ResourceGenerator\RouteBasedCollectionStrategy;
 use Mezzio\Hal\ResourceGeneratorFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use stdClass;
 
 class ResourceGeneratorFactoryTest extends TestCase
 {
+    use PHPUnitDeprecatedAssertions;
+
+    use ProphecyTrait;
+
     /**
      * @var ObjectProphecy|ContainerInterface
      */
     private $container;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
 
@@ -82,7 +87,7 @@ class ResourceGeneratorFactoryTest extends TestCase
     }
 
     /**
-     * @depends missingOrEmptyStrategiesConfiguration
+     * @dataProvider missingOrEmptyStrategiesConfiguration
      */
     public function testFactoryWithoutAnyStrategies(array $config)
     {
@@ -98,7 +103,6 @@ class ResourceGeneratorFactoryTest extends TestCase
 
     public function invalidStrategiesConfig()
     {
-        yield 'null'       => [null];
         yield 'false'      => [false];
         yield 'true'       => [true];
         yield 'zero'       => [0];
@@ -110,7 +114,7 @@ class ResourceGeneratorFactoryTest extends TestCase
     }
 
     /**
-     * @depends invalidStrategiesConfig
+     * @dataProvider invalidStrategiesConfig
      * @param mixed $strategies
      */
     public function testFactoryRaisesExceptionIfStrategiesConfigIsNonTraversable($strategies)

--- a/test/ResourceGeneratorTest.php
+++ b/test/ResourceGeneratorTest.php
@@ -23,6 +23,7 @@ use Mezzio\Hal\ResourceGenerator;
 use Mezzio\Hal\ResourceGenerator\Exception\OutOfBoundsException;
 use MezzioTest\Hal\TestAsset\TestMetadata;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -34,6 +35,10 @@ use stdClass;
 class ResourceGeneratorTest extends TestCase
 {
     use Assertions;
+
+    use PHPUnitDeprecatedAssertions;
+
+    use ProphecyTrait;
 
     /**
      * @var ObjectProphecy|ServerRequestInterface
@@ -60,7 +65,7 @@ class ResourceGeneratorTest extends TestCase
      */
     private $generator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->request = $this->prophesize(ServerRequestInterface::class);
         $this->hydrators = $this->prophesize(ContainerInterface::class);


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

This PR adds support for PHP 8, and aims to solve the issue https://github.com/mezzio/mezzio-hal/issues/18

The only change to the code in the source folder is being done since the code execution breaks in PHP 8 due to the trait having different signature than the child method.

Additional changes were done to test code, to accomodate deprecations from PHPUnit 8, which removed ability to assert object attributes, and the deprecation of Prophecy within PHPUnit.