### PR TITLE
Remove deprecated functionality in preparation for 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ Versions prior to 0.4.0 were released as the package "weierophinney/hal".
 
 ### Removed
 
-- Nothing.
+- [#27](https://github.com/mezzio/mezzio-hal/pull/27) removes support for the `route_identifier_placeholder` configuration setting from `RouteBasedResourceMetadataFactory`; users should use the `identifiers_to_placeholders_mapping` configuration instead to map the resource identifier to the route placeholder.
+
+- [#27](https://github.com/mezzio/mezzio-hal/pull/27) removes the `$routeIdentifierPlaceholder` property and constructor argument from `RouteBasedResourceMetadata`, as well as the `getRouteIdentifierPlaceholder()` method. Users should use the `$identiersToPlaceholdersMapping` argument instead to map resource identifiers to the appropriate route placeholder.
 
 ### Fixed
 

--- a/docs/book/factories.md
+++ b/docs/book/factories.md
@@ -105,12 +105,9 @@ The additional pairs are as follows:
       data.
     - `resource_identifier`: what property in the resource represents its
       identifier; defaults to "id".
-    - `route_identifier_placeholder`: what placeholder in the route string
-      represents the resource identifier; defaults to "id". Deprecated since
-      1.4.0; use the `identifiers_to_placeholders_mapping` setting instead.
     - `route_params`: an array of additional routing parameters to use when
       generating the self relational link for the resource.
-    - `identifiers_to_placeholders_mapping` (associative array mapping resource properties to routing parameters, for use when generating the URI; since 1.4.0)
+    - `identifiers_to_placeholders_mapping` (associative array mapping resource properties to routing parameters, for use when generating the URI)
     - `max_depth`: the number of nesting levels processed. Defaults to 10.
 - For `RouteBasedCollectionMetadata`:
     - `collection_class`: the collection class the metadata describes.

--- a/docs/book/resource-generator.md
+++ b/docs/book/resource-generator.md
@@ -46,12 +46,9 @@ following information:
       use for extracting data from the instance)
     - string `$resourceIdentifier = 'id'` (name of the property uniquely
       identifying the resource)
-    - string `$routeIdentifierPlaceholder = 'id'` (name of the routing parameter
-      that maps to the resource identifier; deprecated since 1.4.0 in favor of
-      using the `$identifiersToPlacholdersMapping`)
     - array `$routeParams = []` (associative array of additional routing
       parameters to substitute when generating the URI)
-    - array `$identifiersToPlacholdersMapping = []` (associative array mapping resource properties to route parameters, for use when generating the URI; available since 1.4.0)
+    - array `$identifiersToPlacholdersMapping = []` (associative array mapping resource properties to route parameters, for use when generating the URI)
     - int `$maxDepth = 10` max allowed nesting levels.
 - `Mezzio\Hal\Metadata\UrlBasedCollectionMetadata`:
     - string `$class`
@@ -128,9 +125,9 @@ The rest of the parameters follow underscore delimiter naming convention:
 
 - `RouteBasedResourceMetadata::class`
     - `resource_identifier` (name of the property uniquely identifying the resource)
-    - `route_identifier_placeholder` (name of the routing parameter that maps to the resource identifier. Deprecated since 1.4.0; use the `identifiers_to_placeholders_mapping` setting instead)
     - `route_params` (associative array of substitutions to use with the designated route)
-    - `identifiers_to_placeholders_mapping` (associative array mapping resource properties to routing parameters, for use when generating the URI; since 1.4.0)
+    - `identifiers_to_placeholders_mapping` (associative array mapping resource properties to routing parameters, for use when generating the URI)
+    - `max_depth` (maximum depth to allow when rendering nested resources; defaults to 10)
 - `RouteBasedCollectionMetadata::class`
     - `pagination_param`  (name of the parameter indicating the current page of results)
     - `pagination_param_type` (one of "query" or "placeholder")

--- a/src/Metadata/RouteBasedResourceMetadata.php
+++ b/src/Metadata/RouteBasedResourceMetadata.php
@@ -11,7 +11,6 @@ namespace Mezzio\Hal\Metadata;
 class RouteBasedResourceMetadata extends AbstractResourceMetadata
 {
     private const DEFAULT_RESOURCE_ID = 'id';
-    private const DEFAULT_ROUTE_ID_PLACEHOLDER = 'id';
 
     /** @var array */
     private $identifiersToPlaceHoldersMapping;
@@ -22,21 +21,14 @@ class RouteBasedResourceMetadata extends AbstractResourceMetadata
     /** @var string */
     private $route;
 
-    /** @var string */
-    private $routeIdentifierPlaceholder;
-
     /** @var array */
     private $routeParams;
 
-    /**
-     * @param string $routeIdentifierPlaceholder Deprecated; use $identifiersToPlaceholdersMapping instead.
-     */
     public function __construct(
         string $class,
         string $route,
         string $extractor,
         string $resourceIdentifier = self::DEFAULT_RESOURCE_ID,
-        string $routeIdentifierPlaceholder = self::DEFAULT_ROUTE_ID_PLACEHOLDER,
         array $routeParams = [],
         array $identifiersToPlaceholdersMapping = [],
         int $maxDepth = 10
@@ -44,28 +36,10 @@ class RouteBasedResourceMetadata extends AbstractResourceMetadata
         $this->class = $class;
         $this->route = $route;
         $this->extractor = $extractor;
-        $this->routeParams = $routeParams;
-        $this->maxDepth = $maxDepth;
-
         $this->resourceIdentifier = $resourceIdentifier;
-        $this->routeIdentifierPlaceholder = $routeIdentifierPlaceholder;
-
-        if (array_key_exists($resourceIdentifier, $identifiersToPlaceholdersMapping)
-            && $routeIdentifierPlaceholder !== self::DEFAULT_ROUTE_ID_PLACEHOLDER
-            && $identifiersToPlaceholdersMapping[$resourceIdentifier] !== $routeIdentifierPlaceholder
-        ) {
-            throw Exception\InvalidConfigException::dueToConflictingRouteIdentifierPlaceholder(
-                $resourceIdentifier,
-                $routeIdentifierPlaceholder,
-                $identifiersToPlaceholdersMapping[$resourceIdentifier]
-            );
-        }
-
-        if (! array_key_exists($resourceIdentifier, $identifiersToPlaceholdersMapping)) {
-            $identifiersToPlaceholdersMapping[$resourceIdentifier] = $routeIdentifierPlaceholder;
-        }
-
+        $this->routeParams = $routeParams;
         $this->identifiersToPlaceHoldersMapping = $identifiersToPlaceholdersMapping;
+        $this->maxDepth = $maxDepth;
     }
 
     public function getRoute() : string
@@ -86,16 +60,6 @@ class RouteBasedResourceMetadata extends AbstractResourceMetadata
     public function getResourceIdentifier() : string
     {
         return $this->resourceIdentifier;
-    }
-
-    /**
-     * This method has been kept for BC and should be deprecated.
-     *
-     * @return string
-     */
-    public function getRouteIdentifierPlaceholder() : string
-    {
-        return $this->routeIdentifierPlaceholder;
     }
 
     public function getRouteParams() : array

--- a/src/Metadata/RouteBasedResourceMetadataFactory.php
+++ b/src/Metadata/RouteBasedResourceMetadataFactory.php
@@ -39,12 +39,6 @@ class RouteBasedResourceMetadataFactory implements MetadataFactoryInterface
      *          // Defaults to "id".
      *          'resource_identifier' => 'id',
      *
-     *          // What placeholder in the route string represents the resource
-     *          // identifier. Defaults to "id".
-     *          // Deprecated since 1.4.0; use the 'identifiers_to_placeholders_mapping'
-     *          // setting instead.
-     *          'route_identifier_placeholder' => 'id',
-     *
      *          // An array of additional routing parameters to use when
      *          // generating the self relational link for the collection
      *          // resource. Defaults to an empty array.
@@ -84,7 +78,6 @@ class RouteBasedResourceMetadataFactory implements MetadataFactoryInterface
             $metadata['route'],
             $metadata['extractor'],
             $metadata['resource_identifier'] ?? 'id',
-            $metadata['route_identifier_placeholder'] ?? 'id',
             $metadata['route_params'] ?? [],
             $metadata['identifiers_to_placeholders_mapping'] ?? ['id' => 'id'],
             $metadata['max_depth'] ?? 10

--- a/test/Metadata/MetadataMapFactoryTest.php
+++ b/test/Metadata/MetadataMapFactoryTest.php
@@ -269,7 +269,6 @@ class MetadataMapFactoryTest extends TestCase
                         'route'                        => 'foo',
                         'extractor'                    => 'ObjectProperty',
                         'resource_identifier'          => 'foo_id',
-                        'route_identifier_placeholder' => 'foo_id',
                         'route_params'                 => ['foo' => 'bar'],
                         'identifiers_to_placeholders_mapping' => [
                             'bar' => 'bar_value',
@@ -295,12 +294,10 @@ class MetadataMapFactoryTest extends TestCase
         $this->assertSame('ObjectProperty', $metadata->getExtractor());
         $this->assertSame('foo', $metadata->getRoute());
         $this->assertSame('foo_id', $metadata->getResourceIdentifier());
-        $this->assertSame('foo_id', $metadata->getRouteIdentifierPlaceholder());
         $this->assertSame(['foo' => 'bar'], $metadata->getRouteParams());
         $this->assertSame([
             'bar'    => 'bar_value',
             'baz'    => 'baz_value',
-            'foo_id' => 'foo_id',
         ], $metadata->getIdentifiersToPlaceholdersMapping());
     }
 
@@ -363,39 +360,5 @@ class MetadataMapFactoryTest extends TestCase
         $metadata = $metadataMap->get(stdClass::class);
 
         $this->assertInstanceOf(TestAsset\TestMetadata::class, $metadata);
-    }
-
-    public function testFactoryRaisesExceptionWhenCreatingRouteBasedResourceMetadataContainingConfigConflicts()
-    {
-        $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn(
-            [
-                MetadataMap::class => [
-                    [
-                        '__class__'                    => RouteBasedResourceMetadata::class,
-                        'resource_class'               => stdClass::class,
-                        'route'                        => 'foo',
-                        'extractor'                    => 'ObjectProperty',
-                        'resource_identifier'          => 'foo_id',
-                        'route_identifier_placeholder' => 'foo_id',
-                        'route_params'                 => ['foo' => 'bar'],
-                        'identifiers_to_placeholders_mapping' => [
-                            'foo_id' => 'id',
-                            'bar'    => 'bar_value',
-                            'baz'    => 'baz_value',
-                        ],
-                    ],
-                ],
-                'mezzio-hal' => [
-                    'metadata-factories' => [
-                        RouteBasedResourceMetadata::class => RouteBasedResourceMetadataFactory::class,
-                    ],
-                ],
-            ]
-        );
-
-        $this->expectException(InvalidConfigException::class);
-        $this->expectExceptionMessage('"$routeIdentifierPlaceholder"');
-        ($this->factory)($this->container->reveal());
     }
 }

--- a/test/ResourceGenerator/ResourceWithSelfReferringInstanceTest.php
+++ b/test/ResourceGenerator/ResourceWithSelfReferringInstanceTest.php
@@ -73,7 +73,6 @@ final class ResourceWithSelfReferringInstanceTest extends TestCase
             'foo-bar',
             self::getObjectPropertyHydratorClass(),
             'id',
-            'id',
             [],
             [],
             0

--- a/test/ResourceGenerator/RouteBasedCollectionWithRouteParamsTest.php
+++ b/test/ResourceGenerator/RouteBasedCollectionWithRouteParamsTest.php
@@ -53,8 +53,8 @@ class RouteBasedCollectionWithRouteParamsTest extends TestCase
             'foo-bar',
             self::getObjectPropertyHydratorClass(),
             'id',
-            'bar_id',
-            ['foo_id' => 1234]
+            ['foo_id' => 1234],
+            ['id' => 'bar_id']
         );
 
         $metadataMap->has(TestAsset\FooBar::class)->willReturn(true);
@@ -131,8 +131,8 @@ class RouteBasedCollectionWithRouteParamsTest extends TestCase
             'foo-bar',
             self::getObjectPropertyHydratorClass(),
             'id',
-            'bar_id',
-            ['foo_id' => 1234]
+            ['foo_id' => 1234],
+            ['id' => 'bar_id']
         );
 
         $metadataMap->has(TestAsset\FooBar::class)->willReturn(true);

--- a/test/ResourceGenerator/UrlBasedCollectionWithRouteParamsTest.php
+++ b/test/ResourceGenerator/UrlBasedCollectionWithRouteParamsTest.php
@@ -49,8 +49,8 @@ class UrlBasedCollectionWithRouteParamsTest extends TestCase
             'foo-bar',
             self::getObjectPropertyHydratorClass(),
             'id',
-            'bar_id',
-            ['foo_id' => 1234]
+            ['foo_id' => 1234],
+            ['id' => 'bar_id']
         );
 
         $metadataMap->has(TestAsset\FooBar::class)->willReturn(true);
@@ -121,8 +121,8 @@ class UrlBasedCollectionWithRouteParamsTest extends TestCase
             'foo-bar',
             self::getObjectPropertyHydratorClass(),
             'id',
-            'bar_id',
-            ['foo_id' => 1234]
+            ['foo_id' => 1234],
+            ['id' => 'bar_id']
         );
 
         $metadataMap->has(TestAsset\FooBar::class)->willReturn(true);

--- a/test/ResourceGeneratorTest.php
+++ b/test/ResourceGeneratorTest.php
@@ -170,8 +170,8 @@ class ResourceGeneratorTest extends TestCase
             'foo-bar',
             self::getObjectPropertyHydratorClass(),
             'id',
-            'foo_bar_id',
-            ['test' => 'param']
+            ['test' => 'param'],
+            ['id' => 'foo_bar_id']
         );
 
         $this->metadataMap->has(TestAsset\FooBar::class)->willReturn(true);
@@ -285,8 +285,8 @@ class ResourceGeneratorTest extends TestCase
             'foo-bar',
             self::getObjectPropertyHydratorClass(),
             'id',
-            'foo_bar_id',
-            ['test' => 'param']
+            ['test' => 'param'],
+            ['id' => 'foo_bar_id']
         );
 
         $this->metadataMap->has(TestAsset\FooBar::class)->willReturn(true);
@@ -417,8 +417,8 @@ class ResourceGeneratorTest extends TestCase
             'foo-bar',
             self::getObjectPropertyHydratorClass(),
             'id',
-            'foo_bar_id',
-            ['test' => 'param']
+            ['test' => 'param'],
+            ['id' => 'foo_bar_id']
         );
 
         $this->metadataMap->has(TestAsset\FooBar::class)->willReturn(true);
@@ -527,8 +527,8 @@ class ResourceGeneratorTest extends TestCase
             'foo-bar',
             self::getObjectPropertyHydratorClass(),
             'id',
-            'foo_bar_id',
-            ['test' => 'param']
+            ['test' => 'param'],
+            ['id' => 'foo_bar_id']
         );
 
         $this->metadataMap->has(TestAsset\FooBar::class)->willReturn(true);
@@ -583,8 +583,8 @@ class ResourceGeneratorTest extends TestCase
             'foo-bar',
             self::getObjectPropertyHydratorClass(),
             'id',
-            'foo_bar_id',
-            ['test' => 'param']
+            ['test' => 'param'],
+            ['id' => 'foo_bar_id']
         );
 
         $this->metadataMap->has(TestAsset\FooBar::class)->willReturn(true);
@@ -639,8 +639,8 @@ class ResourceGeneratorTest extends TestCase
             'foo-bar',
             self::getObjectPropertyHydratorClass(),
             'id',
-            'foo_bar_id',
-            ['test' => 'param']
+            ['test' => 'param'],
+            ['id' => 'foo_bar_id']
         );
 
         $this->metadataMap->has(TestAsset\FooBar::class)->willReturn(true);
@@ -790,8 +790,8 @@ class ResourceGeneratorTest extends TestCase
             'foo-bar',
             self::getObjectPropertyHydratorClass(),
             'id',
-            'foo_bar_id',
-            ['test' => 'param']
+            ['test' => 'param'],
+            ['id' => 'foo_bar_id']
         );
 
         $this->metadataMap->has(TestAsset\FooBar::class)->willReturn(true);
@@ -832,7 +832,6 @@ class ResourceGeneratorTest extends TestCase
             TestAsset\FooBar::class,
             'foo-bar',
             self::getObjectPropertyHydratorClass(),
-            'id',
             'id',
             [],
             [


### PR DESCRIPTION
| Q        | A   |
| -        | -   |
| BC Break | Yes |

Removes functionality deprecated during 1.x series in preparation for 2.0.0 release:

- Removes `$routeIdentifierPlaceholder` property and constructor argument from `RouteBasedResourceMetadata` class
- Removes `getRouteIdentifierPlaceholder` method from `RouteBasedResourceMetadata` class
- Removes support for `route_identifier_placeholder` configuration from `RouteBasedResourceMetadataFactory`

Fixes #26
