### PR TITLE
Update to laminas-coding-standard 2.1 series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpcs-cache
 /.phpunit.result.cache
 /clover.xml
 /composer.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ Versions prior to 0.4.0 were released as the package "weierophinney/hal".
 
 ### Changed
 
+- [#28](https://github.com/mezzio/mezzio-hal/pull/28) adds the `object` typehint to the `$instance` argument of the `StrategyInterface::fromObject()` method.
+  This also affects each of the shipped implementations:
+  - `RouteBasedCollectionStrategy`
+  - `RouteBasedResourceStrategy`
+  - `UrlBasedCollectionStrategy`
+  - `UrlBasedResourceStrategy`
+
+- [#28](https://github.com/mezzio/mezzio-hal/pull/28) adds the `string` typehint to the `$class` argument and a `self` return typehint to `UndefinedMetadataException::create()`.
+
+- [#28](https://github.com/mezzio/mezzio-hal/pull/28) adds the `string` typehint to the `$class` argument and a `self` return typehint to `UndefinedClassException::create()`.
+
+- [#28](https://github.com/mezzio/mezzio-hal/pull/28) adds a `self` return typehint to `DuplicateMetadataException::create()`.
+
+- [#28](https://github.com/mezzio/mezzio-hal/pull/28) adds an `array` return typehint to `HalResource::jsonSerialize()`. It was implied before, but is now made explicit.
+
 - [#22](https://github.com/mezzio/mezzio-hal/pull/22) changes the signature of `ResourceGenerator::fromObject()` to accept an additional, optional `int $depth = 0` argument. This is used to help prevent circular references.
 
 - [#22](https://github.com/mezzio/mezzio-hal/pull/22) adds the method `hasReachedMaxDepth()` to each of the `AbstractMetadata` and `AbstractResourceMetadata` classes, and each metadata implementation now also accepts an additional optional `$maxDepth` argument (with related `max_depth` configuration setting). These are used in conjunction with strategy implementations to prevent circular references.

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.8.1",
-        "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-coding-standard": "~2.1.4",
         "laminas/laminas-hydrator": "^3.2",
         "laminas/laminas-paginator": "^2.9",
         "mezzio/mezzio-helpers": "^5.4",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,8 +1,20 @@
 <?xml version="1.0"?>
-<ruleset name="Laminas Coding Standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+    
+    <!-- Show progress -->
+    <arg value="p"/>
 
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
+
+    <!-- Include all rules from the Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
 </ruleset>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -23,61 +23,60 @@ use Mezzio\Hal\ResourceGenerator\RouteBasedCollectionStrategy;
 use Mezzio\Hal\ResourceGenerator\RouteBasedResourceStrategy;
 use Mezzio\Hal\ResourceGenerator\UrlBasedCollectionStrategy;
 use Mezzio\Hal\ResourceGenerator\UrlBasedResourceStrategy;
+use Zend\Expressive\Hal\LinkGenerator\ExpressiveUrlGenerator;
 
 class ConfigProvider
 {
-    public function __invoke() : array
+    public function __invoke(): array
     {
         return [
-            'dependencies'        => $this->getDependencies(),
-            'mezzio-hal' => $this->getHalConfig(),
+            'dependencies' => $this->getDependencies(),
+            'mezzio-hal'   => $this->getHalConfig(),
         ];
     }
 
-    public function getDependencies() : array
+    public function getDependencies(): array
     {
         return [
-            'aliases' => [
-                UrlGeneratorInterface::class => LinkGenerator\MezzioUrlGenerator::class,
+            'aliases'    => [
+                UrlGeneratorInterface::class      => MezzioUrlGenerator::class,
                 ResourceGeneratorInterface::class => ResourceGenerator::class,
 
                 // Legacy Zend Framework aliases
                 \Zend\Expressive\Hal\LinkGenerator\UrlGeneratorInterface::class => UrlGeneratorInterface::class,
-                \Zend\Expressive\Hal\HalResponseFactory::class => HalResponseFactory::class,
-                \Zend\Expressive\Hal\LinkGenerator::class => LinkGenerator::class,
-                \Zend\Expressive\Hal\LinkGenerator\ExpressiveUrlGenerator::class => MezzioUrlGenerator::class,
-                \Zend\Expressive\Hal\Metadata\MetadataMap::class => MetadataMap::class,
-                \Zend\Expressive\Hal\ResourceGenerator::class => ResourceGenerator::class,
-                \Zend\Expressive\Hal\RouteBasedCollectionStrategy::class => RouteBasedCollectionStrategy::class,
-                \Zend\Expressive\Hal\RouteBasedResourceStrategy::class => RouteBasedResourceStrategy::class,
-                \Zend\Expressive\Hal\UrlBasedCollectionStrategy::class => UrlBasedCollectionStrategy::class,
-                \Zend\Expressive\Hal\UrlBasedResourceStrategy::class => UrlBasedResourceStrategy::class,
+                \Zend\Expressive\Hal\HalResponseFactory::class                  => HalResponseFactory::class,
+                \Zend\Expressive\Hal\LinkGenerator::class                       => LinkGenerator::class,
+                ExpressiveUrlGenerator::class                                   => MezzioUrlGenerator::class,
+                \Zend\Expressive\Hal\Metadata\MetadataMap::class                => MetadataMap::class,
+                \Zend\Expressive\Hal\ResourceGenerator::class                   => ResourceGenerator::class,
+                \Zend\Expressive\Hal\RouteBasedCollectionStrategy::class        => RouteBasedCollectionStrategy::class,
+                \Zend\Expressive\Hal\RouteBasedResourceStrategy::class          => RouteBasedResourceStrategy::class,
+                \Zend\Expressive\Hal\UrlBasedCollectionStrategy::class          => UrlBasedCollectionStrategy::class,
+                \Zend\Expressive\Hal\UrlBasedResourceStrategy::class            => UrlBasedResourceStrategy::class,
             ],
-            'factories' => [
-                HalResponseFactory::class     => HalResponseFactoryFactory::class,
-                LinkGenerator::class          => LinkGeneratorFactory::class,
+            'factories'  => [
+                HalResponseFactory::class => HalResponseFactoryFactory::class,
+                LinkGenerator::class      => LinkGeneratorFactory::class,
                 MezzioUrlGenerator::class => LinkGenerator\MezzioUrlGeneratorFactory::class,
-                MetadataMap::class            => Metadata\MetadataMapFactory::class,
-                ResourceGenerator::class      => ResourceGeneratorFactory::class,
+                MetadataMap::class        => Metadata\MetadataMapFactory::class,
+                ResourceGenerator::class  => ResourceGeneratorFactory::class,
             ],
             'invokables' => [
                 RouteBasedCollectionStrategy::class => RouteBasedCollectionStrategy::class,
                 RouteBasedResourceStrategy::class   => RouteBasedResourceStrategy::class,
-
                 UrlBasedCollectionStrategy::class   => UrlBasedCollectionStrategy::class,
-                UrlBasedResourceStrategy::class     => UrlBasedResourceStrategy::class
+                UrlBasedResourceStrategy::class     => UrlBasedResourceStrategy::class,
             ],
         ];
     }
 
-    public function getHalConfig() : array
+    public function getHalConfig(): array
     {
         return [
             'resource-generator' => [
                 'strategies' => [ // The registered strategies and their metadata types
                     RouteBasedCollectionMetadata::class => RouteBasedCollectionStrategy::class,
                     RouteBasedResourceMetadata::class   => RouteBasedResourceStrategy::class,
-
                     UrlBasedCollectionMetadata::class   => UrlBasedCollectionStrategy::class,
                     UrlBasedResourceMetadata::class     => UrlBasedResourceStrategy::class,
                 ],
@@ -85,7 +84,6 @@ class ConfigProvider
             'metadata-factories' => [ // The factories for the metadata types
                 RouteBasedCollectionMetadata::class => RouteBasedCollectionMetadataFactory::class,
                 RouteBasedResourceMetadata::class   => RouteBasedResourceMetadataFactory::class,
-
                 UrlBasedCollectionMetadata::class   => UrlBasedCollectionMetadataFactory::class,
                 UrlBasedResourceMetadata::class     => UrlBasedResourceMetadataFactory::class,
             ],

--- a/src/Exception/InvalidObjectException.php
+++ b/src/Exception/InvalidObjectException.php
@@ -19,7 +19,7 @@ class InvalidObjectException extends InvalidArgumentException implements Excepti
     /**
      * @param mixed $value Non-object value.
      */
-    public static function forNonObject($value) : self
+    public static function forNonObject($value): self
     {
         return new self(sprintf(
             'Cannot generate %s for non-object value of type "%s"',
@@ -28,7 +28,7 @@ class InvalidObjectException extends InvalidArgumentException implements Excepti
         ));
     }
 
-    public static function forUnknownType(string $class) : self
+    public static function forUnknownType(string $class): self
     {
         return new self(sprintf(
             'Cannot generate %s for object of type %s; not in metadata map',

--- a/src/Exception/InvalidResourceValueException.php
+++ b/src/Exception/InvalidResourceValueException.php
@@ -18,7 +18,10 @@ use function sprintf;
 
 class InvalidResourceValueException extends RuntimeException implements ExceptionInterface
 {
-    public static function fromValue($value) : self
+    /**
+     * @param mixed $value
+     */
+    public static function fromValue($value): self
     {
         return new self(sprintf(
             'Encountered non-primitive type "%s" when serializing %s instance; unable to serialize',
@@ -30,7 +33,7 @@ class InvalidResourceValueException extends RuntimeException implements Exceptio
     /**
      * @param object $object
      */
-    public static function fromObject($object) : self
+    public static function fromObject($object): self
     {
         return new self(sprintf(
             'Encountered object of type "%s" when serializing %s instance; unable to serialize',

--- a/src/Exception/InvalidStrategyException.php
+++ b/src/Exception/InvalidStrategyException.php
@@ -18,7 +18,7 @@ use function sprintf;
 
 class InvalidStrategyException extends InvalidArgumentException implements ExceptionInterface
 {
-    public static function forType(string $strategy) : self
+    public static function forType(string $strategy): self
     {
         return new self(sprintf(
             'Invalid strategy "%s"; does not exist, or does not implement %s',
@@ -30,7 +30,7 @@ class InvalidStrategyException extends InvalidArgumentException implements Excep
     /**
      * @param mixed $strategy
      */
-    public static function forInstance($strategy) : self
+    public static function forInstance($strategy): self
     {
         return new self(sprintf(
             'Invalid strategy of type "%s"; does not implement %s',

--- a/src/Exception/UnknownMetadataTypeException.php
+++ b/src/Exception/UnknownMetadataTypeException.php
@@ -16,7 +16,7 @@ use function sprintf;
 
 class UnknownMetadataTypeException extends RuntimeException implements ExceptionInterface
 {
-    public static function forMetadata(AbstractMetadata $metadata) : self
+    public static function forMetadata(AbstractMetadata $metadata): self
     {
         return new self(sprintf(
             'Encountered unknown metadata type %s; no strategy available for creating resource from this metadata',
@@ -24,7 +24,7 @@ class UnknownMetadataTypeException extends RuntimeException implements Exception
         ));
     }
 
-    public static function forInvalidMetadataClass(string $metadata) : self
+    public static function forInvalidMetadataClass(string $metadata): self
     {
         return new self(sprintf(
             'Invalid metadata type "%s"; does not exist, or does not extend %s',

--- a/src/HalResponseFactory.php
+++ b/src/HalResponseFactory.php
@@ -19,9 +19,12 @@ class HalResponseFactory
     /**
      * @var string Default mediatype to use as the base Content-Type, minus the format.
      */
-    const DEFAULT_CONTENT_TYPE = 'application/hal';
+    public const DEFAULT_CONTENT_TYPE = 'application/hal';
 
-    const NEGOTIATION_PRIORITIES = [
+    /**
+     * @var string[]
+     */
+    public const NEGOTIATION_PRIORITIES = [
         'application/json',
         'application/*+json',
         'application/xml',
@@ -43,35 +46,35 @@ class HalResponseFactory
 
     public function __construct(
         callable $responseFactory,
-        Renderer\JsonRenderer $jsonRenderer = null,
-        Renderer\XmlRenderer $xmlRenderer = null
+        ?Renderer\JsonRenderer $jsonRenderer = null,
+        ?Renderer\XmlRenderer $xmlRenderer = null
     ) {
         // Ensures type safety of the composed factory
-        $this->responseFactory = function () use ($responseFactory) : ResponseInterface {
+        $this->responseFactory = function () use ($responseFactory): ResponseInterface {
             return $responseFactory();
         };
-        $this->jsonRenderer = $jsonRenderer ?: new Renderer\JsonRenderer();
-        $this->xmlRenderer = $xmlRenderer ?: new Renderer\XmlRenderer();
+        $this->jsonRenderer    = $jsonRenderer ?: new Renderer\JsonRenderer();
+        $this->xmlRenderer     = $xmlRenderer ?: new Renderer\XmlRenderer();
     }
 
     public function createResponse(
         ServerRequestInterface $request,
         HalResource $resource,
         string $mediaType = self::DEFAULT_CONTENT_TYPE
-    ) : ResponseInterface {
+    ): ResponseInterface {
         $accept      = $request->getHeaderLine('Accept') ?: '*/*';
         $matchedType = (new Negotiator())->getBest($accept, self::NEGOTIATION_PRIORITIES);
 
         switch (true) {
-            case ($matchedType && strstr($matchedType->getValue(), 'json')):
-                $renderer = $this->jsonRenderer;
-                $mediaType = $mediaType . '+json';
+            case $matchedType && strstr($matchedType->getValue(), 'json'):
+                $renderer   = $this->jsonRenderer;
+                $mediaType .= '+json';
                 break;
-            case (! $matchedType):
+            case ! $matchedType:
                 // fall-through
             default:
-                $renderer = $this->xmlRenderer;
-                $mediaType = $mediaType . '+xml';
+                $renderer   = $this->xmlRenderer;
+                $mediaType .= '+xml';
                 break;
         }
 

--- a/src/HalResponseFactoryFactory.php
+++ b/src/HalResponseFactoryFactory.php
@@ -10,6 +10,8 @@ namespace Mezzio\Hal;
 
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
+use Zend\Expressive\Hal\Renderer\JsonRenderer;
+use Zend\Expressive\Hal\Renderer\XmlRenderer;
 
 /**
  * Create and return a HalResponseFactory instance.
@@ -24,21 +26,21 @@ use Psr\Http\Message\ResponseInterface;
 class HalResponseFactoryFactory
 {
     /**
-     * @throws RuntimeException if neither a ResponseInterface service is
+     * @throws RuntimeException If neither a ResponseInterface service is
      *     present nor laminas-diactoros is installed.
      */
-    public function __invoke(ContainerInterface $container) : HalResponseFactory
+    public function __invoke(ContainerInterface $container): HalResponseFactory
     {
         $jsonRenderer = $container->has(Renderer\JsonRenderer::class)
             ? $container->get(Renderer\JsonRenderer::class)
-            : ($container->has(\Zend\Expressive\Hal\Renderer\JsonRenderer::class)
-                ? $container->get(\Zend\Expressive\Hal\Renderer\JsonRenderer::class)
+            : ($container->has(JsonRenderer::class)
+                ? $container->get(JsonRenderer::class)
                 : new Renderer\JsonRenderer());
 
         $xmlRenderer = $container->has(Renderer\XmlRenderer::class)
             ? $container->get(Renderer\XmlRenderer::class)
-            : ($container->has(\Zend\Expressive\Hal\Renderer\XmlRenderer::class)
-                ? $container->get(\Zend\Expressive\Hal\Renderer\XmlRenderer::class)
+            : ($container->has(XmlRenderer::class)
+                ? $container->get(XmlRenderer::class)
                 : new Renderer\XmlRenderer());
 
         return new HalResponseFactory(

--- a/src/Link.php
+++ b/src/Link.php
@@ -25,43 +25,34 @@ use function sprintf;
 
 class Link implements EvolvableLinkInterface
 {
-    const AS_COLLECTION = '__FORCE_COLLECTION__';
+    public const AS_COLLECTION = '__FORCE_COLLECTION__';
 
-    /**
-     * @var array
-     */
+    /** @var array */
     private $attributes;
 
-    /**
-     * @var string[] Link relation types
-     */
+    /** @var string[] Link relation types */
     private $relations;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $uri;
 
-    /**
-     * @var bool Whether or not the link is templated
-     */
+    /** @var bool Whether or not the link is templated */
     private $isTemplated;
 
     /**
      * @param string|string[] $relation One or more relations represented by this link.
      * @param string|object $uri
-     * @param bool $isTemplated
      * @param array $attributes
-     * @throws InvalidArgumentException if $relation is neither a string nor an array.
-     * @throws InvalidArgumentException if an array $relation is provided, but one or
+     * @throws InvalidArgumentException If $relation is neither a string nor an array.
+     * @throws InvalidArgumentException If an array $relation is provided, but one or
      *     more values is not a string.
      */
     public function __construct($relation, string $uri = '', bool $isTemplated = false, array $attributes = [])
     {
-        $this->relations = $this->validateRelation($relation);
-        $this->uri = is_string($uri) ? $uri : (string) $uri;
+        $this->relations   = $this->validateRelation($relation);
+        $this->uri         = is_string($uri) ? $uri : (string) $uri;
         $this->isTemplated = $isTemplated;
-        $this->attributes = $this->validateAttributes($attributes);
+        $this->attributes  = $this->validateAttributes($attributes);
     }
 
     /**
@@ -98,12 +89,14 @@ class Link implements EvolvableLinkInterface
 
     /**
      * {@inheritDoc}
-     * @throws InvalidArgumentException if $href is not a string, and not an
+     *
+     * @throws InvalidArgumentException If $href is not a string, and not an
      *     object implementing __toString.
      */
     public function withHref($href)
     {
-        if (! is_string($href)
+        if (
+            ! is_string($href)
             && ! (is_object($href) && method_exists($href, '__toString'))
         ) {
             throw new InvalidArgumentException(sprintf(
@@ -112,14 +105,15 @@ class Link implements EvolvableLinkInterface
                 is_object($href) ? get_class($href) : gettype($href)
             ));
         }
-        $new = clone $this;
+        $new      = clone $this;
         $new->uri = (string) $href;
         return $new;
     }
 
     /**
      * {@inheritDoc}
-     * @throws InvalidArgumentException if $rel is not a string.
+     *
+     * @throws InvalidArgumentException If $rel is not a string.
      */
     public function withRel($rel)
     {
@@ -135,7 +129,7 @@ class Link implements EvolvableLinkInterface
             return $this;
         }
 
-        $new = clone $this;
+        $new              = clone $this;
         $new->relations[] = $rel;
         return $new;
     }
@@ -153,7 +147,7 @@ class Link implements EvolvableLinkInterface
             return $this;
         }
 
-        $new = clone $this;
+        $new            = clone $this;
         $new->relations = array_filter($this->relations, function ($value) use ($rel) {
             return $rel !== $value;
         });
@@ -162,9 +156,10 @@ class Link implements EvolvableLinkInterface
 
     /**
      * {@inheritDoc}
-     * @throws InvalidArgumentException if $attribute is not a string or is empty.
-     * @throws InvalidArgumentException if $value is neither a scalar nor an array.
-     * @throws InvalidArgumentException if $value is an array, but one or more values
+     *
+     * @throws InvalidArgumentException If $attribute is not a string or is empty.
+     * @throws InvalidArgumentException If $value is neither a scalar nor an array.
+     * @throws InvalidArgumentException If $value is an array, but one or more values
      *     is not a string.
      */
     public function withAttribute($attribute, $value)
@@ -172,7 +167,7 @@ class Link implements EvolvableLinkInterface
         $this->validateAttributeName($attribute, __METHOD__);
         $this->validateAttributeValue($value, __METHOD__);
 
-        $new = clone $this;
+        $new                         = clone $this;
         $new->attributes[$attribute] = $value;
         return $new;
     }
@@ -197,10 +192,9 @@ class Link implements EvolvableLinkInterface
 
     /**
      * @param mixed $name
-     * @param string $context
-     * @throws InvalidArgumentException if $attribute is not a string or is empty.
+     * @throws InvalidArgumentException If $attribute is not a string or is empty.
      */
-    private function validateAttributeName($name, string $context)
+    private function validateAttributeName($name, string $context): void
     {
         if (! is_string($name) || empty($name)) {
             throw new InvalidArgumentException(sprintf(
@@ -213,12 +207,11 @@ class Link implements EvolvableLinkInterface
 
     /**
      * @param mixed $value
-     * @param string $context
-     * @throws InvalidArgumentException if $value is neither a scalar nor an array.
-     * @throws InvalidArgumentException if $value is an array, but one or more values
+     * @throws InvalidArgumentException If $value is neither a scalar nor an array.
+     * @throws InvalidArgumentException If $value is an array, but one or more values
      *     is not a string.
      */
-    private function validateAttributeValue($value, string $context)
+    private function validateAttributeValue($value, string $context): void
     {
         if (! is_scalar($value) && ! is_array($value)) {
             throw new InvalidArgumentException(sprintf(
@@ -228,9 +221,11 @@ class Link implements EvolvableLinkInterface
             ));
         }
 
-        if (is_array($value) && array_reduce($value, function ($isInvalid, $value) {
-            return $isInvalid || ! is_string($value);
-        }, false)) {
+        if (
+            is_array($value) && array_reduce($value, function ($isInvalid, $value) {
+                return $isInvalid || ! is_string($value);
+            }, false)
+        ) {
             throw new InvalidArgumentException(sprintf(
                 '%s expects $value to contain an array of strings; one or more values was not a string',
                 $context
@@ -238,19 +233,20 @@ class Link implements EvolvableLinkInterface
         }
     }
 
-    private function validateAttributes(array $attributes) : array
+    private function validateAttributes(array $attributes): array
     {
         foreach ($attributes as $name => $value) {
-            $this->validateAttributeName($name, __CLASS__);
-            $this->validateAttributeValue($value, __CLASS__);
+            $this->validateAttributeName($name, self::class);
+            $this->validateAttributeValue($value, self::class);
         }
         return $attributes;
     }
 
     /**
      * @param mixed $relation
-     * @throws InvalidArgumentException if $relation is neither a string nor an array
-     * @throws InvalidArgumentException if $relation is an array, but any given value in it is not a string
+     * @return string|string[]
+     * @throws InvalidArgumentException If $relation is neither a string nor an array.
+     * @throws InvalidArgumentException If $relation is an array, but any given value in it is not a string.
      */
     private function validateRelation($relation)
     {
@@ -261,9 +257,11 @@ class Link implements EvolvableLinkInterface
             ));
         }
 
-        if (is_array($relation) && false === array_reduce($relation, function ($isString, $value) {
-            return $isString === false || is_string($value) || empty($value);
-        }, true)) {
+        if (
+            is_array($relation) && false === array_reduce($relation, function ($isString, $value) {
+                return $isString === false || is_string($value) || empty($value);
+            }, true)
+        ) {
             throw new InvalidArgumentException(
                 'When passing an array for $relation, each value must be a non-empty string; '
                 . 'one or more non-string or empty values were present'

--- a/src/LinkCollection.php
+++ b/src/LinkCollection.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable WebimpressCodingStandard.NamingConventions.Trait.Suffix
 
 /**
  * @see       https://github.com/mezzio/mezzio-hal for the canonical source repository
@@ -8,7 +8,6 @@
 
 namespace Mezzio\Hal;
 
-use Psr\Link\EvolvableLinkProviderInterface;
 use Psr\Link\LinkInterface;
 
 use function array_filter;
@@ -20,9 +19,7 @@ use function in_array;
  */
 trait LinkCollection
 {
-    /**
-     * @var LinkInterface[]
-     */
+    /** @var LinkInterface[] */
     private $links = [];
 
     /**
@@ -53,7 +50,7 @@ trait LinkCollection
             return $this;
         }
 
-        $new = clone $this;
+        $new          = clone $this;
         $new->links[] = $link;
         return $new;
     }
@@ -67,7 +64,7 @@ trait LinkCollection
             return $this;
         }
 
-        $new = clone $this;
+        $new        = clone $this;
         $new->links = array_filter($this->links, function (LinkInterface $compare) use ($link) {
             return $link !== $compare;
         });

--- a/src/LinkGenerator.php
+++ b/src/LinkGenerator.php
@@ -12,9 +12,7 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class LinkGenerator
 {
-    /**
-     * @var LinkGenerator\UrlGeneratorInterface
-     */
+    /** @var LinkGenerator\UrlGeneratorInterface */
     private $urlGenerator;
 
     public function __construct(LinkGenerator\UrlGeneratorInterface $urlGenerator)
@@ -29,7 +27,7 @@ class LinkGenerator
         array $routeParams = [],
         array $queryParams = [],
         array $attributes = []
-    ) : Link {
+    ): Link {
         return new Link($relation, $this->urlGenerator->generate(
             $request,
             $routeName,
@@ -48,7 +46,7 @@ class LinkGenerator
         array $routeParams = [],
         array $queryParams = [],
         array $attributes = []
-    ) : Link {
+    ): Link {
         return new Link($relation, $this->urlGenerator->generate(
             $request,
             $routeName,

--- a/src/LinkGenerator/MezzioUrlGenerator.php
+++ b/src/LinkGenerator/MezzioUrlGenerator.php
@@ -14,19 +14,15 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class MezzioUrlGenerator implements UrlGeneratorInterface
 {
-    /**
-     * @var null|ServerUrlHelper
-     */
+    /** @var null|ServerUrlHelper */
     private $serverUrlHelper;
 
-    /**
-     * @var UrlHelper
-     */
+    /** @var UrlHelper */
     private $urlHelper;
 
-    public function __construct(UrlHelper $urlHelper, ServerUrlHelper $serverUrlHelper = null)
+    public function __construct(UrlHelper $urlHelper, ?ServerUrlHelper $serverUrlHelper = null)
     {
-        $this->urlHelper = $urlHelper;
+        $this->urlHelper       = $urlHelper;
         $this->serverUrlHelper = $serverUrlHelper;
     }
 
@@ -35,7 +31,7 @@ class MezzioUrlGenerator implements UrlGeneratorInterface
         string $routeName,
         array $routeParams = [],
         array $queryParams = []
-    ) : string {
+    ): string {
         $path = $this->urlHelper->generate($routeName, $routeParams, $queryParams);
 
         if (! $this->serverUrlHelper) {

--- a/src/LinkGenerator/MezzioUrlGeneratorFactory.php
+++ b/src/LinkGenerator/MezzioUrlGeneratorFactory.php
@@ -23,7 +23,7 @@ class MezzioUrlGeneratorFactory
     /**
      * Allow serialization
      */
-    public static function __set_state(array $data) : self
+    public static function __set_state(array $data): self
     {
         return new self(
             $data['urlHelperServiceName'] ?? UrlHelper::class
@@ -38,12 +38,12 @@ class MezzioUrlGeneratorFactory
         $this->urlHelperServiceName = $urlHelperServiceName;
     }
 
-    public function __invoke(ContainerInterface $container) : MezzioUrlGenerator
+    public function __invoke(ContainerInterface $container): MezzioUrlGenerator
     {
         if (! $container->has($this->urlHelperServiceName)) {
             throw new RuntimeException(sprintf(
                 '%s requires a %s in order to generate a %s instance; none found',
-                __CLASS__,
+                self::class,
                 $this->urlHelperServiceName,
                 MezzioUrlGenerator::class
             ));

--- a/src/LinkGenerator/UrlGeneratorInterface.php
+++ b/src/LinkGenerator/UrlGeneratorInterface.php
@@ -32,5 +32,5 @@ interface UrlGeneratorInterface
         string $routeName,
         array $routeParams = [],
         array $queryParams = []
-    ) : string;
+    ): string;
 }

--- a/src/LinkGeneratorFactory.php
+++ b/src/LinkGeneratorFactory.php
@@ -18,7 +18,7 @@ class LinkGeneratorFactory
     /**
      * Allow serialization
      */
-    public static function __set_state(array $data) : self
+    public static function __set_state(array $data): self
     {
         return new self(
             $data['urlGeneratorServiceName'] ?? LinkGenerator\UrlGeneratorInterface::class
@@ -33,7 +33,7 @@ class LinkGeneratorFactory
         $this->urlGeneratorServiceName = $urlGeneratorServiceName;
     }
 
-    public function __invoke(ContainerInterface $container) : LinkGenerator
+    public function __invoke(ContainerInterface $container): LinkGenerator
     {
         return new LinkGenerator(
             $container->get($this->urlGeneratorServiceName)

--- a/src/Metadata/AbstractCollectionMetadata.php
+++ b/src/Metadata/AbstractCollectionMetadata.php
@@ -10,8 +10,8 @@ namespace Mezzio\Hal\Metadata;
 
 abstract class AbstractCollectionMetadata extends AbstractMetadata
 {
-    const TYPE_PLACEHOLDER = 'placeholder';
-    const TYPE_QUERY = 'query';
+    public const TYPE_PLACEHOLDER = 'placeholder';
+    public const TYPE_QUERY       = 'query';
 
     /** @var string */
     protected $collectionRelation;
@@ -22,17 +22,17 @@ abstract class AbstractCollectionMetadata extends AbstractMetadata
     /** @var string */
     protected $paginationParamType;
 
-    public function getCollectionRelation() : string
+    public function getCollectionRelation(): string
     {
         return $this->collectionRelation;
     }
 
-    public function getPaginationParam() : string
+    public function getPaginationParam(): string
     {
         return $this->paginationParam;
     }
 
-    public function getPaginationParamType() : string
+    public function getPaginationParamType(): string
     {
         return $this->paginationParamType;
     }

--- a/src/Metadata/AbstractMetadata.php
+++ b/src/Metadata/AbstractMetadata.php
@@ -14,12 +14,10 @@ abstract class AbstractMetadata
 {
     use LinkCollection;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $class;
 
-    public function getClass() : string
+    public function getClass(): string
     {
         return $this->class;
     }

--- a/src/Metadata/AbstractResourceMetadata.php
+++ b/src/Metadata/AbstractResourceMetadata.php
@@ -13,6 +13,7 @@ abstract class AbstractResourceMetadata extends AbstractMetadata
     /**
      * Service name of an ExtractionInterface implementation to use when
      * extracting a resource of this type.
+     *
      * @var string
      */
     protected $extractor;
@@ -20,7 +21,7 @@ abstract class AbstractResourceMetadata extends AbstractMetadata
     /** @var int */
     protected $maxDepth;
 
-    public function getExtractor() : string
+    public function getExtractor(): string
     {
         return $this->extractor;
     }

--- a/src/Metadata/Exception/DuplicateMetadataException.php
+++ b/src/Metadata/Exception/DuplicateMetadataException.php
@@ -14,7 +14,7 @@ use function sprintf;
 
 class DuplicateMetadataException extends DomainException implements ExceptionInterface
 {
-    public static function create(string $class)
+    public static function create(string $class): self
     {
         return new self(sprintf(
             'Attempted to add metadata for class "%s", which already has metadata in the map',

--- a/src/Metadata/Exception/InvalidConfigException.php
+++ b/src/Metadata/Exception/InvalidConfigException.php
@@ -26,7 +26,7 @@ class InvalidConfigException extends RuntimeException implements ExceptionInterf
     /**
      * @param mixed $config
      */
-    public static function dueToNonArray($config) : self
+    public static function dueToNonArray($config): self
     {
         return new self(sprintf(
             'Invalid %s configuration; expected an array, but received %s',
@@ -35,7 +35,10 @@ class InvalidConfigException extends RuntimeException implements ExceptionInterf
         ));
     }
 
-    public static function dueToNonArrayMetadata($metadata) : self
+    /**
+     * @param mixed $metadata
+     */
+    public static function dueToNonArrayMetadata($metadata): self
     {
         return new self(sprintf(
             'Invalid %s metadata item configuration; expected an array, but received %s',
@@ -44,7 +47,7 @@ class InvalidConfigException extends RuntimeException implements ExceptionInterf
         ));
     }
 
-    public static function dueToMissingMetadataClass() : self
+    public static function dueToMissingMetadataClass(): self
     {
         return new self('Unable to generate metadata; missing "__class__" element');
     }
@@ -52,7 +55,7 @@ class InvalidConfigException extends RuntimeException implements ExceptionInterf
     /**
      * @param mixed $class
      */
-    public static function dueToInvalidMetadataClass($class) : self
+    public static function dueToInvalidMetadataClass($class): self
     {
         $className = $class;
         if (! is_string($className)) {
@@ -64,7 +67,7 @@ class InvalidConfigException extends RuntimeException implements ExceptionInterf
         ));
     }
 
-    public static function dueToNonMetadataClass(string $class) : self
+    public static function dueToNonMetadataClass(string $class): self
     {
         return new self(sprintf(
             '%s is not a valid metadata class; does not extend %s',
@@ -73,7 +76,7 @@ class InvalidConfigException extends RuntimeException implements ExceptionInterf
         ));
     }
 
-    public static function dueToInvalidMetadataFactoryClass(string $class) : self
+    public static function dueToInvalidMetadataFactoryClass(string $class): self
     {
         return new self(sprintf(
             '%s is not a valid metadata factory class; does not implement %s',
@@ -82,7 +85,7 @@ class InvalidConfigException extends RuntimeException implements ExceptionInterf
         ));
     }
 
-    public static function dueToUnrecognizedMetadataClass(string $class) : self
+    public static function dueToUnrecognizedMetadataClass(string $class): self
     {
         return new self(sprintf(
             '%s does not know how to construct a %s instance; please provide a '
@@ -92,7 +95,7 @@ class InvalidConfigException extends RuntimeException implements ExceptionInterf
         ));
     }
 
-    public static function dueToMissingMetadata(string $type, array $requiredKeys) : self
+    public static function dueToMissingMetadata(string $type, array $requiredKeys): self
     {
         return new self(sprintf(
             'Unable to create HAL metadata of type %s; one or more of the '
@@ -106,7 +109,7 @@ class InvalidConfigException extends RuntimeException implements ExceptionInterf
         string $resourceIdentifier,
         string $routeIdentifierPlaceholder,
         string $routeIdentifierPlaceholderFromMapping
-    ) : self {
+    ): self {
         return new self(sprintf(
             'You have specified both a "$routeIdentifierPlaceholder" value ("%s") and provided one for the'
             . ' "%s" (resourceIdentifier) key of the $identifiersToPlaceholdersMapping" (with value "%s"),'

--- a/src/Metadata/Exception/UndefinedClassException.php
+++ b/src/Metadata/Exception/UndefinedClassException.php
@@ -14,7 +14,7 @@ use function sprintf;
 
 class UndefinedClassException extends UnexpectedValueException implements ExceptionInterface
 {
-    public static function create($class)
+    public static function create(string $class): self
     {
         return new self(sprintf(
             'Cannot map metadata for class "%s"; class does not exist',

--- a/src/Metadata/Exception/UndefinedMetadataException.php
+++ b/src/Metadata/Exception/UndefinedMetadataException.php
@@ -14,7 +14,7 @@ use function sprintf;
 
 class UndefinedMetadataException extends RuntimeException implements ExceptionInterface
 {
-    public static function create($class)
+    public static function create(string $class): self
     {
         return new self(sprintf(
             'Unable to retrieve metadata for "%s"; no matching metadata found',

--- a/src/Metadata/MetadataFactoryInterface.php
+++ b/src/Metadata/MetadataFactoryInterface.php
@@ -27,7 +27,6 @@ interface MetadataFactoryInterface
      *
      *     The '__class__' key decides which AbstractMetadata should be used
      *     (and which corresponding factory will be called to create it).
-     * @return AbstractMetadata
      */
-    public function createMetadata(string $requestedName, array $metadata) : AbstractMetadata;
+    public function createMetadata(string $requestedName, array $metadata): AbstractMetadata;
 }

--- a/src/Metadata/MetadataMap.php
+++ b/src/Metadata/MetadataMap.php
@@ -12,15 +12,19 @@ use function class_exists;
 
 class MetadataMap
 {
+    /**
+     * @var array
+     * @psalm-var array<string, AbstractMetadata>
+     */
     private $map = [];
 
     /**
-     * @throws Exception\DuplicateMetadataException if metadata matching the
+     * @throws Exception\DuplicateMetadataException If metadata matching the
      *     class of the provided metadata already exists in the map.
-     * @throws Exception\UndefinedClassException if the class in the provided
+     * @throws Exception\UndefinedClassException If the class in the provided
      *     metadata does not exist.
      */
-    public function add(AbstractMetadata $metadata) : void
+    public function add(AbstractMetadata $metadata): void
     {
         $class = $metadata->getClass();
         if (isset($this->map[$class])) {
@@ -34,16 +38,16 @@ class MetadataMap
         $this->map[$class] = $metadata;
     }
 
-    public function has(string $class) : bool
+    public function has(string $class): bool
     {
         return isset($this->map[$class]);
     }
 
     /**
-     * @throws Exception\UndefinedMetadataException if no metadata matching the
+     * @throws Exception\UndefinedMetadataException If no metadata matching the
      *     provided class is found in the map.
      */
-    public function get(string $class) : AbstractMetadata
+    public function get(string $class): AbstractMetadata
     {
         if (! isset($this->map[$class])) {
             throw Exception\UndefinedMetadataException::create($class);

--- a/src/Metadata/MetadataMapFactory.php
+++ b/src/Metadata/MetadataMapFactory.php
@@ -48,7 +48,7 @@ use function sprintf;
  */
 class MetadataMapFactory
 {
-    public function __invoke(ContainerInterface $container) : MetadataMap
+    public function __invoke(ContainerInterface $container): MetadataMap
     {
         $config            = $container->has('config') ? $container->get('config') : [];
         $metadataMapConfig = $config[MetadataMap::class] ?? [];
@@ -70,7 +70,7 @@ class MetadataMapFactory
         MetadataMap $metadataMap,
         array $metadataMapConfig,
         array $metadataFactories
-    ) : MetadataMap {
+    ): MetadataMap {
         foreach ($metadataMapConfig as $metadata) {
             if (! is_array($metadata)) {
                 throw Exception\InvalidConfigException::dueToNonArrayMetadata($metadata);
@@ -83,13 +83,13 @@ class MetadataMapFactory
     }
 
     /**
-     * @throws Exception\InvalidConfigException if the metadata is missing a
+     * @throws Exception\InvalidConfigException If the metadata is missing a
      *     "__class__" entry.
-     * @throws Exception\InvalidConfigException if the "__class__" entry is not
+     * @throws Exception\InvalidConfigException If the "__class__" entry is not
      *     a class.
-     * @throws Exception\InvalidConfigException if the "__class__" entry is not
+     * @throws Exception\InvalidConfigException If the "__class__" entry is not
      *     an AbstractMetadata class.
-     * @throws Exception\InvalidConfigException if no matching `create*()`
+     * @throws Exception\InvalidConfigException If no matching `create*()`
      *     method is found for the "__class__" entry.
      */
     private function injectMetadata(MetadataMap $metadataMap, array $metadata, array $metadataFactories)
@@ -127,22 +127,19 @@ class MetadataMapFactory
     /**
      * Uses the registered factory class to create the metadata instance.
      *
-     * @param string $metadataClass
-     * @param string $factoryClass
      * @param array  $metadata
-     * @return AbstractMetadata
      */
     private function createMetadataViaFactoryClass(
         string $metadataClass,
         array $metadata,
         string $factoryClass
-    ) : AbstractMetadata {
+    ): AbstractMetadata {
         if (! in_array(MetadataFactoryInterface::class, class_implements($factoryClass), true)) {
             throw Exception\InvalidConfigException::dueToInvalidMetadataFactoryClass($factoryClass);
         }
 
         $factory = new $factoryClass();
-        /* @var $factory MetadataFactoryInterface */
+        /** @var MetadataFactoryInterface $factory */
         return $factory->createMetadata($metadataClass, $metadata);
     }
 
@@ -151,11 +148,9 @@ class MetadataMapFactory
      *
      * This function is to ensure backwards compatibility with versions prior to 0.6.0.
      *
-     * @param string $metadataClass
      * @param array  $metadata
-     * @return AbstractMetadata
      */
-    private function createMetadataViaFactoryMethod(string $metadataClass, array $metadata) : AbstractMetadata
+    private function createMetadataViaFactoryMethod(string $metadataClass, array $metadata): AbstractMetadata
     {
         $normalizedClass = $this->stripNamespaceFromClass($metadataClass);
         $method          = sprintf('create%s', $normalizedClass);
@@ -167,7 +162,7 @@ class MetadataMapFactory
         return $this->$method($metadata);
     }
 
-    private function stripNamespaceFromClass(string $class) : string
+    private function stripNamespaceFromClass(string $class): string
     {
         $segments = explode('\\', $class);
         return array_pop($segments);

--- a/src/Metadata/RouteBasedCollectionMetadata.php
+++ b/src/Metadata/RouteBasedCollectionMetadata.php
@@ -28,26 +28,26 @@ class RouteBasedCollectionMetadata extends AbstractCollectionMetadata
         array $routeParams = [],
         array $queryStringArguments = []
     ) {
-        $this->class = $class;
-        $this->collectionRelation = $collectionRelation;
-        $this->route = $route;
-        $this->paginationParam = $paginationParam;
-        $this->paginationParamType = $paginationParamType;
-        $this->routeParams = $routeParams;
+        $this->class                = $class;
+        $this->collectionRelation   = $collectionRelation;
+        $this->route                = $route;
+        $this->paginationParam      = $paginationParam;
+        $this->paginationParamType  = $paginationParamType;
+        $this->routeParams          = $routeParams;
         $this->queryStringArguments = $queryStringArguments;
     }
 
-    public function getRoute() : string
+    public function getRoute(): string
     {
         return $this->route;
     }
 
-    public function getRouteParams() : array
+    public function getRouteParams(): array
     {
         return $this->routeParams;
     }
 
-    public function getQueryStringArguments() : array
+    public function getQueryStringArguments(): array
     {
         return $this->queryStringArguments;
     }
@@ -58,7 +58,7 @@ class RouteBasedCollectionMetadata extends AbstractCollectionMetadata
      * In particular, this is useful for setting a parent identifier
      * in the route when dealing with child resources.
      */
-    public function setRouteParams(array $routeParams) : void
+    public function setRouteParams(array $routeParams): void
     {
         $this->routeParams = $routeParams;
     }
@@ -69,7 +69,7 @@ class RouteBasedCollectionMetadata extends AbstractCollectionMetadata
      * In particular, this is useful for setting query string arguments for
      * searches, sorts, limits, etc.
      */
-    public function setQueryStringArguments(array $query) : void
+    public function setQueryStringArguments(array $query): void
     {
         $this->queryStringArguments = $query;
     }

--- a/src/Metadata/RouteBasedCollectionMetadataFactory.php
+++ b/src/Metadata/RouteBasedCollectionMetadataFactory.php
@@ -55,10 +55,9 @@ class RouteBasedCollectionMetadataFactory implements MetadataFactoryInterface
      *          'query_string_arguments' => [],
      *     ]
      *     </code>
-     * @return AbstractMetadata
      * @throws Exception\InvalidConfigException
      */
-    public function createMetadata(string $requestedName, array $metadata) : AbstractMetadata
+    public function createMetadata(string $requestedName, array $metadata): AbstractMetadata
     {
         $requiredKeys = [
             'collection_class',

--- a/src/Metadata/RouteBasedResourceMetadata.php
+++ b/src/Metadata/RouteBasedResourceMetadata.php
@@ -33,41 +33,39 @@ class RouteBasedResourceMetadata extends AbstractResourceMetadata
         array $identifiersToPlaceholdersMapping = [],
         int $maxDepth = 10
     ) {
-        $this->class = $class;
-        $this->route = $route;
-        $this->extractor = $extractor;
-        $this->resourceIdentifier = $resourceIdentifier;
-        $this->routeParams = $routeParams;
+        $this->class                            = $class;
+        $this->route                            = $route;
+        $this->extractor                        = $extractor;
+        $this->resourceIdentifier               = $resourceIdentifier;
+        $this->routeParams                      = $routeParams;
         $this->identifiersToPlaceHoldersMapping = $identifiersToPlaceholdersMapping;
-        $this->maxDepth = $maxDepth;
+        $this->maxDepth                         = $maxDepth;
     }
 
-    public function getRoute() : string
+    public function getRoute(): string
     {
         return $this->route;
     }
 
-    public function getIdentifiersToPlaceholdersMapping() : array
+    public function getIdentifiersToPlaceholdersMapping(): array
     {
         return $this->identifiersToPlaceHoldersMapping;
     }
 
     /**
      * This method has been kept for BC and should be deprecated.
-     *
-     * @return string
      */
-    public function getResourceIdentifier() : string
+    public function getResourceIdentifier(): string
     {
         return $this->resourceIdentifier;
     }
 
-    public function getRouteParams() : array
+    public function getRouteParams(): array
     {
         return $this->routeParams;
     }
 
-    public function setRouteParams(array $routeParams) : void
+    public function setRouteParams(array $routeParams): void
     {
         $this->routeParams = $routeParams;
     }

--- a/src/Metadata/RouteBasedResourceMetadataFactory.php
+++ b/src/Metadata/RouteBasedResourceMetadataFactory.php
@@ -55,15 +55,14 @@ class RouteBasedResourceMetadataFactory implements MetadataFactoryInterface
      *          'max_depth' => 10,
      *     ]
      *     </code>
-     * @return AbstractMetadata
      * @throws Exception\InvalidConfigException
      */
-    public function createMetadata(string $requestedName, array $metadata) : AbstractMetadata
+    public function createMetadata(string $requestedName, array $metadata): AbstractMetadata
     {
         $requiredKeys = [
             'resource_class',
             'route',
-            'extractor'
+            'extractor',
         ];
 
         if ($requiredKeys !== array_intersect($requiredKeys, array_keys($metadata))) {

--- a/src/Metadata/UrlBasedCollectionMetadata.php
+++ b/src/Metadata/UrlBasedCollectionMetadata.php
@@ -17,6 +17,7 @@ class UrlBasedCollectionMetadata extends AbstractCollectionMetadata
 {
     /**
      * URL to use for the `self` relation of the collection.
+     *
      * @var string
      */
     private $url;
@@ -52,7 +53,7 @@ class UrlBasedCollectionMetadata extends AbstractCollectionMetadata
         $this->paginationParamType = $paginationParamType;
     }
 
-    public function getUrl() : string
+    public function getUrl(): string
     {
         return $this->url;
     }

--- a/src/Metadata/UrlBasedCollectionMetadataFactory.php
+++ b/src/Metadata/UrlBasedCollectionMetadataFactory.php
@@ -46,10 +46,9 @@ class UrlBasedCollectionMetadataFactory implements MetadataFactoryInterface
      *          'pagination_param_type' => AbstractCollectionMetadata::TYPE_QUERY,
      *     ]
      *     </code>
-     * @return AbstractMetadata
      * @throws Exception\InvalidConfigException
      */
-    public function createMetadata(string $requestedName, array $metadata) : AbstractMetadata
+    public function createMetadata(string $requestedName, array $metadata): AbstractMetadata
     {
         $requiredKeys = [
             'collection_class',

--- a/src/Metadata/UrlBasedResourceMetadata.php
+++ b/src/Metadata/UrlBasedResourceMetadata.php
@@ -10,20 +10,18 @@ namespace Mezzio\Hal\Metadata;
 
 class UrlBasedResourceMetadata extends AbstractResourceMetadata
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $url;
 
     public function __construct(string $class, string $url, string $extractor, int $maxDepth = 10)
     {
-        $this->class = $class;
-        $this->url = $url;
+        $this->class     = $class;
+        $this->url       = $url;
         $this->extractor = $extractor;
-        $this->maxDepth = $maxDepth;
+        $this->maxDepth  = $maxDepth;
     }
 
-    public function getUrl() : string
+    public function getUrl(): string
     {
         return $this->url;
     }

--- a/src/Metadata/UrlBasedResourceMetadataFactory.php
+++ b/src/Metadata/UrlBasedResourceMetadataFactory.php
@@ -38,10 +38,9 @@ class UrlBasedResourceMetadataFactory implements MetadataFactoryInterface
      *          'max_depth' => 10,
      *     ]
      *     </code>
-     * @return AbstractMetadata
      * @throws Exception\InvalidConfigException
      */
-    public function createMetadata(string $requestedName, array $metadata) : AbstractMetadata
+    public function createMetadata(string $requestedName, array $metadata): AbstractMetadata
     {
         $requiredKeys = [
             'resource_class',

--- a/src/Renderer/JsonRenderer.php
+++ b/src/Renderer/JsonRenderer.php
@@ -29,7 +29,7 @@ class JsonRenderer implements RendererInterface
         $this->jsonFlags = $jsonFlags;
     }
 
-    public function render(HalResource $resource) : string
+    public function render(HalResource $resource): string
     {
         return json_encode($resource, $this->jsonFlags);
     }

--- a/src/Renderer/RendererInterface.php
+++ b/src/Renderer/RendererInterface.php
@@ -12,5 +12,5 @@ use Mezzio\Hal\HalResource;
 
 interface RendererInterface
 {
-    public function render(HalResource $resource) : string;
+    public function render(HalResource $resource): string;
 }

--- a/src/Renderer/XmlRenderer.php
+++ b/src/Renderer/XmlRenderer.php
@@ -23,15 +23,15 @@ use function trim;
 
 class XmlRenderer implements RendererInterface
 {
-    public function render(HalResource $resource) : string
+    public function render(HalResource $resource): string
     {
-        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom               = new DOMDocument('1.0', 'UTF-8');
         $dom->formatOutput = true;
         $dom->appendChild($this->createResourceNode($dom, $resource->toArray()));
         return trim($dom->saveXML());
     }
 
-    private function createResourceNode(DOMDocument $doc, array $resource, string $resourceRel = 'self') : DOMNode
+    private function createResourceNode(DOMDocument $doc, array $resource, string $resourceRel = 'self'): DOMNode
     {
         // Normalize resource
         $resource['_links']    = $resource['_links'] ?? [];
@@ -79,7 +79,7 @@ class XmlRenderer implements RendererInterface
         return $this->createNodeTree($doc, $node, $resource);
     }
 
-    private function createLinkNode(DOMDocument $doc, string $rel, array $data)
+    private function createLinkNode(DOMDocument $doc, string $rel, array $data): DOMNode
     {
         $link = $doc->createElement('link');
         $link->setAttribute('rel', $rel);
@@ -105,12 +105,13 @@ class XmlRenderer implements RendererInterface
         return $value;
     }
 
-    private function isAssocArray(array $value) : bool
+    private function isAssocArray(array $value): bool
     {
         return array_values($value) !== $value;
     }
 
     /**
+     * @param mixed $data
      * @return DOMNode|DOMNode[]
      */
     private function createResourceElement(DOMDocument $doc, string $name, $data)
@@ -144,7 +145,7 @@ class XmlRenderer implements RendererInterface
         return $elements;
     }
 
-    private function createNodeTree(DOMDocument $doc, DOMNode $node, array $data) : DOMNode
+    private function createNodeTree(DOMDocument $doc, DOMNode $node, array $data): DOMNode
     {
         foreach ($data as $key => $value) {
             $element = $this->createResourceElement($doc, $key, $value);
@@ -165,10 +166,10 @@ class XmlRenderer implements RendererInterface
      *     json_decode(json_encode($object), true), passing the final value
      *     back to createResourceElement()?
      * @param object $object
-     * @throws Exception\InvalidResourceValueException if unable to serialize
+     * @throws Exception\InvalidResourceValueException If unable to serialize
      *     the data to a string.
      */
-    private function createDataFromObject($object) : string
+    private function createDataFromObject($object): string
     {
         if ($object instanceof DateTimeInterface) {
             return $object->format('c');

--- a/src/ResourceGenerator.php
+++ b/src/ResourceGenerator.php
@@ -21,24 +21,16 @@ use function is_string;
 
 class ResourceGenerator implements ResourceGeneratorInterface
 {
-    /**
-     * @var ContainerInterface Service locator for hydrators.
-     */
+    /** @var ContainerInterface Service locator for hydrators. */
     private $hydrators;
 
-    /**
-     * @var LinkGenerator Route-based link generation.
-     */
+    /** @var LinkGenerator Route-based link generation. */
     private $linkGenerator;
 
-    /**
-     * @var Metadata\MetadataMap Metadata on known objects.
-     */
+    /** @var Metadata\MetadataMap Metadata on known objects. */
     private $metadataMap;
 
-    /**
-     * @var ResourceGenerator\StrategyInterface[]
-     */
+    /** @var ResourceGenerator\StrategyInterface[] */
     private $strategies = [];
 
     public function __construct(
@@ -46,22 +38,22 @@ class ResourceGenerator implements ResourceGeneratorInterface
         ContainerInterface $hydrators,
         LinkGenerator $linkGenerator
     ) {
-        $this->metadataMap = $metadataMap;
-        $this->hydrators = $hydrators;
+        $this->metadataMap   = $metadataMap;
+        $this->hydrators     = $hydrators;
         $this->linkGenerator = $linkGenerator;
     }
 
-    public function getHydrators() : ContainerInterface
+    public function getHydrators(): ContainerInterface
     {
         return $this->hydrators;
     }
 
-    public function getLinkGenerator() : LinkGenerator
+    public function getLinkGenerator(): LinkGenerator
     {
         return $this->linkGenerator;
     }
 
-    public function getMetadataMap() : Metadata\MetadataMap
+    public function getMetadataMap(): Metadata\MetadataMap
     {
         return $this->metadataMap;
     }
@@ -69,18 +61,19 @@ class ResourceGenerator implements ResourceGeneratorInterface
     /**
      * Link a metadata type to a strategy that can create a resource for it.
      *
-     * @param string $metadataType
      * @param string|ResourceGenerator\StrategyInterface $strategy
      */
-    public function addStrategy(string $metadataType, $strategy) : void
+    public function addStrategy(string $metadataType, $strategy): void
     {
-        if (! class_exists($metadataType)
+        if (
+            ! class_exists($metadataType)
             || ! in_array(Metadata\AbstractMetadata::class, class_parents($metadataType), true)
         ) {
             throw Exception\UnknownMetadataTypeException::forInvalidMetadataClass($metadataType);
         }
 
-        if (is_string($strategy)
+        if (
+            is_string($strategy)
             && (
                 ! class_exists($strategy)
                 || ! in_array(ResourceGenerator\StrategyInterface::class, class_implements($strategy), true)
@@ -103,12 +96,12 @@ class ResourceGenerator implements ResourceGeneratorInterface
     /**
      * Returns the registered strategies.
      */
-    public function getStrategies() : array
+    public function getStrategies(): array
     {
         return $this->strategies;
     }
 
-    public function fromArray(array $data, string $uri = null) : HalResource
+    public function fromArray(array $data, ?string $uri = null): HalResource
     {
         $resource = new HalResource($data);
 
@@ -122,9 +115,8 @@ class ResourceGenerator implements ResourceGeneratorInterface
     /**
      * @param object $instance An object of any type; the type will be checked
      *     against types registered in the metadata map.
-     * @param ServerRequestInterface $request
      */
-    public function fromObject($instance, ServerRequestInterface $request, int $depth = 0) : HalResource
+    public function fromObject(object $instance, ServerRequestInterface $request, int $depth = 0): HalResource
     {
         if (! is_object($instance)) {
             throw Exception\InvalidObjectException::forNonObject($instance);
@@ -135,7 +127,7 @@ class ResourceGenerator implements ResourceGeneratorInterface
             throw Exception\InvalidObjectException::forUnknownType($class);
         }
 
-        $metadata = $this->metadataMap->get($class);
+        $metadata     = $this->metadataMap->get($class);
         $metadataType = get_class($metadata);
 
         if (! isset($this->strategies[$metadataType])) {

--- a/src/ResourceGenerator/Exception/InvalidCollectionException.php
+++ b/src/ResourceGenerator/Exception/InvalidCollectionException.php
@@ -20,7 +20,7 @@ class InvalidCollectionException extends RuntimeException implements ExceptionIn
     /**
      * @param mixed $instance The invalid collection instance or value.
      */
-    public static function fromInstance($instance, string $class) : self
+    public static function fromInstance($instance, string $class): self
     {
         return new self(sprintf(
             '%s is unable to create a resource for collection of type "%s"; not a Traversable',

--- a/src/ResourceGenerator/Exception/InvalidConfigException.php
+++ b/src/ResourceGenerator/Exception/InvalidConfigException.php
@@ -21,7 +21,7 @@ class InvalidConfigException extends RuntimeException implements ExceptionInterf
     /**
      * @param mixed $config
      */
-    public static function dueToNonArray($config) : self
+    public static function dueToNonArray($config): self
     {
         return new self(sprintf(
             'Invalid %s configuration; expected an array or ArrayAccess instance, but received %s',
@@ -33,7 +33,7 @@ class InvalidConfigException extends RuntimeException implements ExceptionInterf
     /**
      * @param mixed $strategies
      */
-    public static function dueToInvalidStrategies($strategies) : self
+    public static function dueToInvalidStrategies($strategies): self
     {
         return new self(sprintf(
             'Invalid mezzio-hal.resource-generator.strategies configuration; '

--- a/src/ResourceGenerator/Exception/InvalidExtractorException.php
+++ b/src/ResourceGenerator/Exception/InvalidExtractorException.php
@@ -21,7 +21,7 @@ class InvalidExtractorException extends RuntimeException implements ExceptionInt
     /**
      * @param mixed $extractor
      */
-    public static function fromInstance($extractor) : self
+    public static function fromInstance($extractor): self
     {
         return new self(sprintf(
             'Invalid extractor "%s" provided in metadata; does not implement %s',

--- a/src/ResourceGenerator/Exception/UnexpectedMetadataTypeException.php
+++ b/src/ResourceGenerator/Exception/UnexpectedMetadataTypeException.php
@@ -17,7 +17,7 @@ use function sprintf;
 
 class UnexpectedMetadataTypeException extends RuntimeException implements ExceptionInterface
 {
-    public static function forMetadata(AbstractMetadata $metadata, string $strategy, string $expected) : self
+    public static function forMetadata(AbstractMetadata $metadata, string $strategy, string $expected): self
     {
         return new self(sprintf(
             'Unexpected metadata of type %s was mapped to %s (expects %s)',
@@ -27,7 +27,7 @@ class UnexpectedMetadataTypeException extends RuntimeException implements Except
         ));
     }
 
-    public static function forCollection(AbstractMetadata $metadata, string $strategyClass) : self
+    public static function forCollection(AbstractMetadata $metadata, string $strategyClass): self
     {
         return new self(sprintf(
             'Error extracting collection via strategy %s; expected %s instance, but received %s',

--- a/src/ResourceGenerator/ExtractInstanceTrait.php
+++ b/src/ResourceGenerator/ExtractInstanceTrait.php
@@ -12,6 +12,7 @@ use Laminas\Hydrator\ExtractionInterface;
 use Mezzio\Hal\Metadata\AbstractCollectionMetadata;
 use Mezzio\Hal\Metadata\AbstractMetadata;
 use Mezzio\Hal\ResourceGeneratorInterface;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 use function get_class;
@@ -20,17 +21,15 @@ use function is_object;
 trait ExtractInstanceTrait
 {
     /**
-     * @param object $instance
-     * @throws \Psr\Container\ContainerExceptionInterface if the extractor
-     *     service cannot be retrieved.
+     * @throws ContainerExceptionInterface If the extractor service cannot be retrieved.
      */
     private function extractInstance(
-        $instance,
+        object $instance,
         AbstractMetadata $metadata,
         ResourceGeneratorInterface $resourceGenerator,
         ServerRequestInterface $request,
         int $depth = 0
-    ) : array {
+    ): array {
         $hydrators = $resourceGenerator->getHydrators();
         $extractor = $hydrators->get($metadata->getExtractor());
         if (! $extractor instanceof ExtractionInterface) {

--- a/src/ResourceGenerator/RouteBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/RouteBasedCollectionStrategy.php
@@ -16,7 +16,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Traversable;
 
 use function array_merge;
-use function get_class;
 
 class RouteBasedCollectionStrategy implements StrategyInterface
 {
@@ -25,12 +24,12 @@ class RouteBasedCollectionStrategy implements StrategyInterface
     }
 
     public function createResource(
-        $instance,
+        object $instance,
         Metadata\AbstractMetadata $metadata,
         ResourceGeneratorInterface $resourceGenerator,
         ServerRequestInterface $request,
         int $depth = 0
-    ) : HalResource {
+    ): HalResource {
         if (! $metadata instanceof Metadata\RouteBasedCollectionMetadata) {
             throw Exception\UnexpectedMetadataTypeException::forMetadata(
                 $metadata,
@@ -40,7 +39,7 @@ class RouteBasedCollectionStrategy implements StrategyInterface
         }
 
         if (! $instance instanceof Traversable) {
-            throw Exception\InvalidCollectionException::fromInstance($instance, get_class($this));
+            throw Exception\InvalidCollectionException::fromInstance($instance, static::class);
         }
 
         return $this->extractCollection($instance, $metadata, $resourceGenerator, $request, $depth);
@@ -56,7 +55,6 @@ class RouteBasedCollectionStrategy implements StrategyInterface
      *     generator in order to generate link based on routing information.
      * @param ServerRequestInterface $request Passed to link generator when
      *     generating link based on routing information.
-     * @return Link
      */
     protected function generateLinkForPage(
         string $rel,
@@ -64,18 +62,18 @@ class RouteBasedCollectionStrategy implements StrategyInterface
         Metadata\AbstractCollectionMetadata $metadata,
         ResourceGeneratorInterface $resourceGenerator,
         ServerRequestInterface $request
-    ) : Link {
-        $route = $metadata->getRoute();
-        $paginationType = $metadata->getPaginationParamType();
+    ): Link {
+        $route           = $metadata->getRoute();
+        $paginationType  = $metadata->getPaginationParamType();
         $paginationParam = $metadata->getPaginationParam();
-        $routeParams = $metadata->getRouteParams();
+        $routeParams     = $metadata->getRouteParams();
         $queryStringArgs = $metadata->getQueryStringArguments();
 
         $paramsWithPage = [$paginationParam => $page];
-        $routeParams = $paginationType === Metadata\AbstractCollectionMetadata::TYPE_PLACEHOLDER
+        $routeParams    = $paginationType === Metadata\AbstractCollectionMetadata::TYPE_PLACEHOLDER
             ? array_merge($routeParams, $paramsWithPage)
             : $routeParams;
-        $queryParams = $paginationType === Metadata\AbstractCollectionMetadata::TYPE_QUERY
+        $queryParams    = $paginationType === Metadata\AbstractCollectionMetadata::TYPE_QUERY
             ? array_merge($queryStringArgs, $paramsWithPage)
             : $queryStringArgs;
 
@@ -104,8 +102,7 @@ class RouteBasedCollectionStrategy implements StrategyInterface
         ResourceGeneratorInterface $resourceGenerator,
         ServerRequestInterface $request
     ) {
-
-        $routeParams = $metadata->getRouteParams() ?? [];
+        $routeParams     = $metadata->getRouteParams() ?? [];
         $queryStringArgs = array_merge($request->getQueryParams() ?? [], $metadata->getQueryStringArguments() ?? []);
 
         return $resourceGenerator

--- a/src/ResourceGenerator/RouteBasedResourceStrategy.php
+++ b/src/ResourceGenerator/RouteBasedResourceStrategy.php
@@ -13,17 +13,20 @@ use Mezzio\Hal\Metadata;
 use Mezzio\Hal\ResourceGeneratorInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+use function array_key_exists;
+use function is_scalar;
+
 class RouteBasedResourceStrategy implements StrategyInterface
 {
     use ExtractInstanceTrait;
 
     public function createResource(
-        $instance,
+        object $instance,
         Metadata\AbstractMetadata $metadata,
         ResourceGeneratorInterface $resourceGenerator,
         ServerRequestInterface $request,
         int $depth = 0
-    ) : HalResource {
+    ): HalResource {
         if (! $metadata instanceof Metadata\RouteBasedResourceMetadata) {
             throw Exception\UnexpectedMetadataTypeException::forMetadata(
                 $metadata,
@@ -67,7 +70,7 @@ class RouteBasedResourceStrategy implements StrategyInterface
                 $request,
                 $metadata->getRoute(),
                 $routeParams
-            )
+            ),
         ]);
     }
 }

--- a/src/ResourceGenerator/StrategyInterface.php
+++ b/src/ResourceGenerator/StrategyInterface.php
@@ -17,14 +17,14 @@ interface StrategyInterface
 {
     /**
      * @param object $instance Instance from which to create HalResource.
-     * @throws Exception\UnexpectedMetadataTypeException for metadata types the
+     * @throws Exception\UnexpectedMetadataTypeException For metadata types the
      *     strategy cannot handle.
      */
     public function createResource(
-        $instance,
+        object $instance,
         Metadata\AbstractMetadata $metadata,
         ResourceGeneratorInterface $resourceGenerator,
         ServerRequestInterface $request,
         int $depth = 0
-    ) : HalResource;
+    ): HalResource;
 }

--- a/src/ResourceGenerator/UrlBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/UrlBasedCollectionStrategy.php
@@ -15,7 +15,6 @@ use Mezzio\Hal\ResourceGeneratorInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Traversable;
 
-use function get_class;
 use function http_build_query;
 use function parse_str;
 use function parse_url;
@@ -33,12 +32,12 @@ class UrlBasedCollectionStrategy implements StrategyInterface
     }
 
     public function createResource(
-        $instance,
+        object $instance,
         Metadata\AbstractMetadata $metadata,
         ResourceGeneratorInterface $resourceGenerator,
         ServerRequestInterface $request,
         int $depth = 0
-    ) : HalResource {
+    ): HalResource {
         if (! $metadata instanceof Metadata\UrlBasedCollectionMetadata) {
             throw Exception\UnexpectedMetadataTypeException::forMetadata(
                 $metadata,
@@ -48,7 +47,7 @@ class UrlBasedCollectionStrategy implements StrategyInterface
         }
 
         if (! $instance instanceof Traversable) {
-            throw Exception\InvalidCollectionException::fromInstance($instance, get_class($this));
+            throw Exception\InvalidCollectionException::fromInstance($instance, static::class);
         }
 
         return $this->extractCollection($instance, $metadata, $resourceGenerator, $request, $depth);
@@ -64,7 +63,6 @@ class UrlBasedCollectionStrategy implements StrategyInterface
      *     abstract.
      * @param ServerRequestInterface $request Ignored; required to fulfill
      *     abstract.
-     * @return Link
      */
     protected function generateLinkForPage(
         string $rel,
@@ -72,10 +70,10 @@ class UrlBasedCollectionStrategy implements StrategyInterface
         Metadata\AbstractCollectionMetadata $metadata,
         ResourceGeneratorInterface $resourceGenerator,
         ServerRequestInterface $request
-    ) : Link {
+    ): Link {
         $paginationParam = $metadata->getPaginationParam();
-        $paginationType = $metadata->getPaginationParamType();
-        $url = $metadata->getUrl() . '?' . http_build_query($request->getQueryParams());
+        $paginationType  = $metadata->getPaginationParamType();
+        $url             = $metadata->getUrl() . '?' . http_build_query($request->getQueryParams());
 
         switch ($paginationType) {
             case Metadata\AbstractCollectionMetadata::TYPE_PLACEHOLDER:
@@ -105,9 +103,8 @@ class UrlBasedCollectionStrategy implements StrategyInterface
         ResourceGeneratorInterface $resourceGenerator,
         ServerRequestInterface $request
     ) {
-
         $queryStringArgs = $request->getQueryParams();
-        $url = $metadata->getUrl();
+        $url             = $metadata->getUrl();
         if ($queryStringArgs !== null) {
             $url .= '?' . http_build_query($queryStringArgs);
         }
@@ -115,7 +112,7 @@ class UrlBasedCollectionStrategy implements StrategyInterface
         return new Link('self', $url);
     }
 
-    private function stripUrlFragment(string $url) : string
+    private function stripUrlFragment(string $url): string
     {
         $fragment = parse_url($url, PHP_URL_FRAGMENT);
         if (null === $fragment) {
@@ -126,7 +123,7 @@ class UrlBasedCollectionStrategy implements StrategyInterface
         return str_replace('#' . $fragment, '', $url);
     }
 
-    private function appendPageQueryToUrl(string $url, int $page, string $paginationParam) : string
+    private function appendPageQueryToUrl(string $url, int $page, string $paginationParam): string
     {
         $query = parse_url($url, PHP_URL_QUERY);
         if (null === $query) {

--- a/src/ResourceGenerator/UrlBasedResourceStrategy.php
+++ b/src/ResourceGenerator/UrlBasedResourceStrategy.php
@@ -19,12 +19,12 @@ class UrlBasedResourceStrategy implements StrategyInterface
     use ExtractInstanceTrait;
 
     public function createResource(
-        $instance,
+        object $instance,
         Metadata\AbstractMetadata $metadata,
         ResourceGeneratorInterface $resourceGenerator,
         ServerRequestInterface $request,
         int $depth = 0
-    ) : HalResource {
+    ): HalResource {
         if (! $metadata instanceof Metadata\UrlBasedResourceMetadata) {
             throw Exception\UnexpectedMetadataTypeException::forMetadata(
                 $metadata,

--- a/src/ResourceGeneratorFactory.php
+++ b/src/ResourceGeneratorFactory.php
@@ -24,7 +24,7 @@ class ResourceGeneratorFactory
     /**
      * Allow serialization
      */
-    public static function __set_state(array $data) : self
+    public static function __set_state(array $data): self
     {
         return new self(
             $data['linkGeneratorServiceName'] ?? LinkGenerator::class
@@ -39,7 +39,7 @@ class ResourceGeneratorFactory
         $this->linkGeneratorServiceName = $linkGeneratorServiceName;
     }
 
-    public function __invoke(ContainerInterface $container) : ResourceGenerator
+    public function __invoke(ContainerInterface $container): ResourceGenerator
     {
         $generator = new ResourceGenerator(
             $container->get(Metadata\MetadataMap::class),
@@ -53,12 +53,12 @@ class ResourceGeneratorFactory
     }
 
     /**
-     * @throws InvalidConfigException if the config service is not an array or
+     * @throws InvalidConfigException If the config service is not an array or
      *     ArrayAccess implementation.
-     * @throws InvalidConfigException if the configured strategies value is not
+     * @throws InvalidConfigException If the configured strategies value is not
      *     an array or traversable.
      */
-    private function injectStrategies(ContainerInterface $container, ResourceGenerator $generator) : void
+    private function injectStrategies(ContainerInterface $container, ResourceGenerator $generator): void
     {
         if (! $container->has('config')) {
             return;

--- a/src/ResourceGeneratorInterface.php
+++ b/src/ResourceGeneratorInterface.php
@@ -13,13 +13,13 @@ use Psr\Http\Message\ServerRequestInterface;
 
 interface ResourceGeneratorInterface
 {
-    public function getHydrators() : ContainerInterface;
+    public function getHydrators(): ContainerInterface;
 
-    public function getMetadataMap() : Metadata\MetadataMap;
+    public function getMetadataMap(): Metadata\MetadataMap;
 
-    public function getLinkGenerator() : LinkGenerator;
+    public function getLinkGenerator(): LinkGenerator;
 
-    public function fromArray(array $data, string $uri = null) : HalResource;
+    public function fromArray(array $data, ?string $uri = null): HalResource;
 
-    public function fromObject($instance, ServerRequestInterface $request, int $depth = 0) : HalResource;
+    public function fromObject(object $instance, ServerRequestInterface $request, int $depth = 0): HalResource;
 }

--- a/test/Assertions.php
+++ b/test/Assertions.php
@@ -23,16 +23,17 @@ use function is_object;
 use function sprintf;
 use function var_export;
 
+// phpcs:ignore WebimpressCodingStandard.NamingConventions.Trait.Suffix
 trait Assertions
 {
-    public static function getObjectPropertyHydratorClass() : string
+    public static function getObjectPropertyHydratorClass(): string
     {
         return class_exists(ObjectPropertyHydrator::class)
             ? ObjectPropertyHydrator::class
             : ObjectProperty::class;
     }
 
-    public static function getLinkByRel(string $rel, HalResource $resource) : Link
+    public static function getLinkByRel(string $rel, HalResource $resource): Link
     {
         $links = $resource->getLinksByRel($rel);
         self::assertIsArray($links, sprintf("Did not receive list of links for rel %s", $rel));
@@ -44,7 +45,10 @@ trait Assertions
         return array_shift($links);
     }
 
-    public static function assertLink(string $expectedRel, string $expectedHref, $actual) : void
+    /**
+     * @param mixed $actual
+     */
+    public static function assertLink(string $expectedRel, string $expectedHref, $actual): void
     {
         self::assertThat($actual instanceof Link, self::isTrue(), sprintf(
             'Invalid link encountered of type %s',

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -15,17 +15,15 @@ use PHPUnit\Framework\TestCase;
 
 class ConfigProviderTest extends TestCase
 {
-    /**
-     * @var ConfigProvider
-     */
+    /** @var ConfigProvider */
     private $provider;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->provider = new ConfigProvider();
     }
 
-    public function testInvocationReturnsArray() : array
+    public function testInvocationReturnsArray(): array
     {
         $config = ($this->provider)();
         self::assertIsArray($config);
@@ -36,7 +34,7 @@ class ConfigProviderTest extends TestCase
     /**
      * @depends testInvocationReturnsArray
      */
-    public function testReturnedArrayContainsDependencies(array $config) : void
+    public function testReturnedArrayContainsDependencies(array $config): void
     {
         self::assertArrayHasKey('dependencies', $config);
         self::assertArrayHasKey('mezzio-hal', $config);

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -22,7 +22,7 @@ use function substr;
 
 class ExceptionTest extends TestCase
 {
-    public function exception() : Generator
+    public function exception(): Generator
     {
         $namespace = substr(ExceptionInterface::class, 0, strrpos(ExceptionInterface::class, '\\') + 1);
 
@@ -37,7 +37,7 @@ class ExceptionTest extends TestCase
     /**
      * @dataProvider exception
      */
-    public function testExceptionIsInstanceOfExceptionInterface(string $exception) : void
+    public function testExceptionIsInstanceOfExceptionInterface(string $exception): void
     {
         self::assertStringContainsString('Exception', $exception);
         self::assertTrue(is_a($exception, ExceptionInterface::class, true));

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -24,7 +24,10 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $resource->getElements());
     }
 
-    public function invalidElementNames()
+    /**
+     * @psalm-return array<string, array{0: string, 1: string}>
+     */
+    public function invalidElementNames(): array
     {
         return [
             'empty'     => ['', 'cannot be empty'],
@@ -56,7 +59,7 @@ class HalResourceTest extends TestCase
 
     public function testCanConstructWithLinks()
     {
-        $links = [
+        $links    = [
             new Link('self', 'https://example.com/'),
             new Link('about', 'https://example.com/about'),
         ];
@@ -114,9 +117,9 @@ class HalResourceTest extends TestCase
 
     public function testWithLinkReturnsNewInstanceContainingNewLink()
     {
-        $link = new Link('self');
+        $link     = new Link('self');
         $resource = new HalResource();
-        $new = $resource->withLink($link);
+        $new      = $resource->withLink($link);
         $this->assertNotSame($resource, $new);
         $this->assertEquals([], $resource->getLinksByRel('self'));
         $this->assertEquals([$link], $new->getLinksByRel('self'));
@@ -124,17 +127,17 @@ class HalResourceTest extends TestCase
 
     public function testWithLinkReturnsSameInstanceIfAlreadyContainsLinkInstance()
     {
-        $link = new Link('self');
+        $link     = new Link('self');
         $resource = new HalResource([], [$link]);
-        $new = $resource->withLink($link);
+        $new      = $resource->withLink($link);
         $this->assertSame($resource, $new);
     }
 
     public function testWithoutLinkReturnsNewInstanceRemovingLink()
     {
-        $link = new Link('self');
+        $link     = new Link('self');
         $resource = new HalResource([], [$link]);
-        $new = $resource->withoutLink($link);
+        $new      = $resource->withoutLink($link);
         $this->assertNotSame($resource, $new);
         $this->assertEquals([$link], $resource->getLinksByRel('self'));
         $this->assertEquals([], $new->getLinksByRel('self'));
@@ -142,17 +145,17 @@ class HalResourceTest extends TestCase
 
     public function testWithoutLinkReturnsSameInstanceIfLinkIsNotPresent()
     {
-        $link = new Link('self');
+        $link     = new Link('self');
         $resource = new HalResource();
-        $new = $resource->withoutLink($link);
+        $new      = $resource->withoutLink($link);
         $this->assertSame($resource, $new);
     }
 
     public function testGetLinksByRelReturnsAllLinksWithGivenRelationshipAsArray()
     {
-        $link1 = new Link('self');
-        $link2 = new Link('about');
-        $link3 = new Link('self');
+        $link1    = new Link('self');
+        $link2    = new Link('about');
+        $link3    = new Link('self');
         $resource = new HalResource();
 
         $resource = $resource
@@ -188,7 +191,7 @@ class HalResourceTest extends TestCase
     public function testWithElementReturnsNewInstanceWithNewElement()
     {
         $resource = new HalResource();
-        $new = $resource->withElement('foo', 'bar');
+        $new      = $resource->withElement('foo', 'bar');
         $this->assertNotSame($resource, $new);
         $this->assertEquals([], $resource->getElements());
         $this->assertEquals(['foo' => 'bar'], $new->getElements());
@@ -197,7 +200,7 @@ class HalResourceTest extends TestCase
     public function testWithElementReturnsNewInstanceOverwritingExistingElementValue()
     {
         $resource = new HalResource(['foo' => 'bar']);
-        $new = $resource->withElement('foo', 'baz');
+        $new      = $resource->withElement('foo', 'baz');
         $this->assertNotSame($resource, $new);
         $this->assertEquals(['foo' => 'bar'], $resource->getElements());
         $this->assertEquals(['foo' => 'baz'], $new->getElements());
@@ -207,7 +210,7 @@ class HalResourceTest extends TestCase
     {
         $embedded = new HalResource(['foo' => 'bar']);
         $resource = new HalResource();
-        $new = $resource->withElement('foo', $embedded);
+        $new      = $resource->withElement('foo', $embedded);
         $this->assertNotSame($resource, $new);
         $this->assertEquals([], $resource->getElements());
         $this->assertEquals(['foo' => $embedded], $new->getElements());
@@ -219,13 +222,13 @@ class HalResourceTest extends TestCase
 
     public function testWithElementProxiesToEmbedIfResourceCollectionValueProvided()
     {
-        $resource1 = new HalResource(['foo' => 'bar']);
-        $resource2 = new HalResource(['foo' => 'baz']);
-        $resource3 = new HalResource(['foo' => 'bat']);
+        $resource1  = new HalResource(['foo' => 'bar']);
+        $resource2  = new HalResource(['foo' => 'baz']);
+        $resource3  = new HalResource(['foo' => 'bat']);
         $collection = [$resource1, $resource2, $resource3];
 
         $resource = new HalResource();
-        $new = $resource->withElement('foo', $collection);
+        $new      = $resource->withElement('foo', $collection);
         $this->assertNotSame($resource, $new);
         $this->assertEquals([], $resource->getElements());
         $this->assertEquals(['foo' => $collection], $new->getElements());
@@ -234,7 +237,7 @@ class HalResourceTest extends TestCase
     public function testWithElementDoesNotProxyToEmbedIfAnEmptyArrayValueIsProvided()
     {
         $resource = new HalResource(['foo' => 'bar']);
-        $new = $resource->withElement('bar', []);
+        $new      = $resource->withElement('bar', []);
 
         $representation = $new->toArray();
         $this->assertEquals(['foo' => 'bar', 'bar' => []], $representation);
@@ -263,7 +266,7 @@ class HalResourceTest extends TestCase
     {
         $embedded = new HalResource(['foo' => 'bar']);
         $resource = new HalResource();
-        $new = $resource->embed('foo', $embedded);
+        $new      = $resource->embed('foo', $embedded);
         $this->assertNotSame($resource, $new);
         $this->assertEquals([], $resource->getElements());
         $this->assertEquals(['foo' => $embedded], $new->getElements());
@@ -271,13 +274,13 @@ class HalResourceTest extends TestCase
 
     public function testEmbedReturnsNewInstanceWithEmbeddedCollection()
     {
-        $resource1 = new HalResource(['foo' => 'bar']);
-        $resource2 = new HalResource(['foo' => 'baz']);
-        $resource3 = new HalResource(['foo' => 'bat']);
+        $resource1  = new HalResource(['foo' => 'bar']);
+        $resource2  = new HalResource(['foo' => 'baz']);
+        $resource3  = new HalResource(['foo' => 'bat']);
         $collection = [$resource1, $resource2, $resource3];
 
         $resource = new HalResource();
-        $new = $resource->embed('foo', $collection);
+        $new      = $resource->embed('foo', $collection);
         $this->assertNotSame($resource, $new);
         $this->assertEquals([], $resource->getElements());
         $this->assertEquals(['foo' => $collection], $new->getElements());
@@ -289,7 +292,7 @@ class HalResourceTest extends TestCase
         $resource2 = new HalResource(['foo' => 'baz']);
 
         $resource = new HalResource(['foo' => $resource1]);
-        $new = $resource->embed('foo', $resource2);
+        $new      = $resource->embed('foo', $resource2);
         $this->assertNotSame($resource, $new);
         $this->assertEquals(['foo' => $resource1], $resource->getElements());
         $this->assertEquals(['foo' => [$resource1, $resource2]], $new->getElements());
@@ -297,13 +300,13 @@ class HalResourceTest extends TestCase
 
     public function testEmbedReturnsNewInstanceAppendingResourceToExistingCollection()
     {
-        $resource1 = new HalResource(['foo' => 'bar']);
-        $resource2 = new HalResource(['foo' => 'baz']);
-        $resource3 = new HalResource(['foo' => 'bat']);
+        $resource1  = new HalResource(['foo' => 'bar']);
+        $resource2  = new HalResource(['foo' => 'baz']);
+        $resource3  = new HalResource(['foo' => 'bat']);
         $collection = [$resource1, $resource2];
 
         $resource = new HalResource(['foo' => $collection]);
-        $new = $resource->embed('foo', $resource3);
+        $new      = $resource->embed('foo', $resource3);
         $this->assertNotSame($resource, $new);
         $this->assertEquals(['foo' => $collection], $resource->getElements());
         $this->assertEquals(['foo' => [$resource1, $resource2, $resource3]], $new->getElements());
@@ -311,15 +314,15 @@ class HalResourceTest extends TestCase
 
     public function testEmbedReturnsNewInstanceAppendingCollectionToExistingCollection()
     {
-        $resource1 = new HalResource(['foo' => 'bar']);
-        $resource2 = new HalResource(['foo' => 'baz']);
-        $resource3 = new HalResource(['foo' => 'bat']);
-        $resource4 = new HalResource(['foo' => 'bat']);
+        $resource1   = new HalResource(['foo' => 'bar']);
+        $resource2   = new HalResource(['foo' => 'baz']);
+        $resource3   = new HalResource(['foo' => 'bat']);
+        $resource4   = new HalResource(['foo' => 'bat']);
         $collection1 = [$resource1, $resource2];
         $collection2 = [$resource3, $resource4];
 
         $resource = new HalResource(['foo' => $collection1]);
-        $new = $resource->embed('foo', $collection2);
+        $new      = $resource->embed('foo', $collection2);
         $this->assertNotSame($resource, $new);
         $this->assertEquals(['foo' => $collection1], $resource->getElements());
         $this->assertEquals(['foo' => $collection1 + $collection2], $new->getElements());
@@ -338,9 +341,9 @@ class HalResourceTest extends TestCase
 
     public function testEmbedRaisesExceptionIfNewResourceDoesNotMatchCollectionResourceStructure()
     {
-        $resource1 = new HalResource(['foo' => 'bar']);
-        $resource2 = new HalResource(['foo' => 'baz']);
-        $resource3 = new HalResource(['bar' => 'bat']);
+        $resource1  = new HalResource(['foo' => 'bar']);
+        $resource2  = new HalResource(['foo' => 'baz']);
+        $resource3  = new HalResource(['bar' => 'bat']);
         $collection = [$resource1, $resource2];
 
         $resource = new HalResource(['foo' => $collection]);
@@ -351,8 +354,8 @@ class HalResourceTest extends TestCase
 
     public function testEmbedRaisesExceptionIfResourcesInCollectionAreNotOfSameStructure()
     {
-        $resource1 = new HalResource(['foo' => 'bar']);
-        $resource2 = new HalResource(['bar' => 'bat']);
+        $resource1  = new HalResource(['foo' => 'bar']);
+        $resource2  = new HalResource(['bar' => 'bat']);
         $collection = [$resource1, $resource2];
 
         $resource = new HalResource();
@@ -364,7 +367,7 @@ class HalResourceTest extends TestCase
     public function testWithElementsAddsNewDataToNewResourceInstance()
     {
         $resource = new HalResource();
-        $new = $resource->withElements(['foo' => 'bar']);
+        $new      = $resource->withElements(['foo' => 'bar']);
         $this->assertNotSame($resource, $new);
         $this->assertEquals([], $resource->getElements());
         $this->assertEquals(['foo' => 'bar'], $new->getElements());
@@ -374,7 +377,7 @@ class HalResourceTest extends TestCase
     {
         $embedded = new HalResource(['foo' => 'bar']);
         $resource = new HalResource();
-        $new = $resource->withElements(['foo' => $embedded]);
+        $new      = $resource->withElements(['foo' => $embedded]);
         $this->assertNotSame($resource, $new);
         $this->assertEquals([], $resource->getElements());
         $this->assertEquals(['foo' => $embedded], $new->getElements());
@@ -387,7 +390,7 @@ class HalResourceTest extends TestCase
     public function testWithElementsOverwritesExistingDataInNewResourceInstance()
     {
         $resource = new HalResource(['foo' => 'bar']);
-        $new = $resource->withElements(['foo' => 'baz']);
+        $new      = $resource->withElements(['foo' => 'baz']);
         $this->assertNotSame($resource, $new);
         $this->assertEquals(['foo' => 'bar'], $resource->getElements());
         $this->assertEquals(['foo' => 'baz'], $new->getElements());
@@ -397,8 +400,8 @@ class HalResourceTest extends TestCase
     {
         $resource1 = new HalResource(['foo' => 'bar']);
         $resource2 = new HalResource(['foo' => 'bar']);
-        $resource = new HalResource(['foo' => $resource1]);
-        $new = $resource->withElements(['foo' => $resource2]);
+        $resource  = new HalResource(['foo' => $resource1]);
+        $new       = $resource->withElements(['foo' => $resource2]);
 
         $this->assertNotSame($resource, $new);
         $this->assertEquals(['foo' => $resource1], $resource->getElements());
@@ -408,7 +411,7 @@ class HalResourceTest extends TestCase
     public function testWithoutElementRemovesDataElementIfItIsPresent()
     {
         $resource = new HalResource(['foo' => 'bar']);
-        $new = $resource->withoutElement('foo');
+        $new      = $resource->withoutElement('foo');
         $this->assertNotSame($resource, $new);
         $this->assertEquals(['foo' => 'bar'], $resource->getElements());
         $this->assertEquals([], $new->getElements());
@@ -417,7 +420,7 @@ class HalResourceTest extends TestCase
     public function testWithoutElementDoesNothingIfElementOrResourceNotPresent()
     {
         $resource = new HalResource(['foo' => 'bar']);
-        $new = $resource->withoutElement('bar');
+        $new      = $resource->withoutElement('bar');
         $this->assertSame($resource, $new);
     }
 
@@ -425,7 +428,7 @@ class HalResourceTest extends TestCase
     {
         $embedded = new HalResource();
         $resource = new HalResource(['foo' => $embedded]);
-        $new = $resource->withoutElement('foo');
+        $new      = $resource->withoutElement('foo');
         $this->assertNotSame($resource, $new);
         $this->assertEquals(['foo' => $embedded], $resource->getElements());
         $this->assertEquals([], $new->getElements());
@@ -433,12 +436,12 @@ class HalResourceTest extends TestCase
 
     public function testWithoutElementRemovesEmbeddedCollectionIfPresent()
     {
-        $resource1 = new HalResource();
-        $resource2 = new HalResource();
-        $resource3 = new HalResource();
+        $resource1  = new HalResource();
+        $resource2  = new HalResource();
+        $resource3  = new HalResource();
         $collection = [$resource1, $resource2, $resource3];
-        $resource = new HalResource(['foo' => $collection]);
-        $new = $resource->withoutElement('foo');
+        $resource   = new HalResource(['foo' => $collection]);
+        $new        = $resource->withoutElement('foo');
         $this->assertNotSame($resource, $new);
         $this->assertEquals(['foo' => $collection], $resource->getElements());
         $this->assertEquals([], $new->getElements());
@@ -455,7 +458,10 @@ class HalResourceTest extends TestCase
         $resource->withoutElement($name);
     }
 
-    public function populatedResources()
+    /**
+     * @psalm-return iterable<string, array{0: HalResource, 1: array}>
+     */
+    public function populatedResources(): iterable
     {
         $resource = (new HalResource())
             ->withLink(new Link('self', '/api/foo'))
@@ -468,10 +474,10 @@ class HalResourceTest extends TestCase
                 new HalResource(['baz' => 'bat', 'id' => 987653], [new Link('self', '/api/baz/987653')]),
             ]);
         $expected = [
-            'foo' => 'bar',
-            'id'  => 12345678,
-            '_links' => [
-                'self' => [
+            'foo'       => 'bar',
+            'id'        => 12345678,
+            '_links'    => [
+                'self'  => [
                     'href' => '/api/foo',
                 ],
                 'about' => [
@@ -481,22 +487,22 @@ class HalResourceTest extends TestCase
             ],
             '_embedded' => [
                 'bar' => [
-                    'bar' => 'baz',
+                    'bar'    => 'baz',
                     '_links' => [
                         'self' => ['href' => '/api/bar'],
                     ],
                 ],
                 'baz' => [
                     [
-                        'baz' => 'bat',
-                        'id'  => 987654,
+                        'baz'    => 'bat',
+                        'id'     => 987654,
                         '_links' => [
                             'self' => ['href' => '/api/baz/987654'],
                         ],
                     ],
                     [
-                        'baz' => 'bat',
-                        'id'  => 987653,
+                        'baz'    => 'bat',
+                        'id'     => 987653,
                         '_links' => [
                             'self' => ['href' => '/api/baz/987653'],
                         ],
@@ -535,7 +541,7 @@ class HalResourceTest extends TestCase
             );
 
         $expected = [
-            '_links' => [
+            '_links'    => [
                 'self' => [
                     'href' => '/api/foo',
                 ],
@@ -543,7 +549,7 @@ class HalResourceTest extends TestCase
             '_embedded' => [
                 'bar' => [
                     [
-                        'bar' => 'baz',
+                        'bar'    => 'baz',
                         '_links' => [
                             'self' => ['href' => '/api/bar'],
                         ],
@@ -557,7 +563,7 @@ class HalResourceTest extends TestCase
 
     public function testAllowsForcingLinkToAggregateAsACollection()
     {
-        $link = new Link('foo', '/api/foo', false, [Link::AS_COLLECTION => true]);
+        $link     = new Link('foo', '/api/foo', false, [Link::AS_COLLECTION => true]);
         $resource = new HalResource(['id' => 'foo'], [$link]);
 
         $expected = [
@@ -568,7 +574,7 @@ class HalResourceTest extends TestCase
                     ],
                 ],
             ],
-            'id' => 'foo',
+            'id'     => 'foo',
         ];
 
         $this->assertEquals($expected, $resource->toArray());

--- a/test/HalResponseFactoryFactoryTest.php
+++ b/test/HalResponseFactoryFactoryTest.php
@@ -19,6 +19,8 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use ReflectionProperty;
+use Zend\Expressive\Hal\Renderer\JsonRenderer;
+use Zend\Expressive\Hal\Renderer\XmlRenderer;
 
 class HalResponseFactoryFactoryTest extends TestCase
 {
@@ -26,7 +28,7 @@ class HalResponseFactoryFactoryTest extends TestCase
 
     use ProphecyTrait;
 
-    public static function assertResponseFactoryReturns(ResponseInterface $expected, HalResponseFactory $factory) : void
+    public static function assertResponseFactoryReturns(ResponseInterface $expected, HalResponseFactory $factory): void
     {
         $r = new ReflectionProperty($factory, 'responseFactory');
         $r->setAccessible(true);
@@ -34,11 +36,11 @@ class HalResponseFactoryFactoryTest extends TestCase
         Assert::assertSame($expected, $responseFactory());
     }
 
-    public function testReturnsHalResponseFactoryInstance() : void
+    public function testReturnsHalResponseFactoryInstance(): void
     {
-        $jsonRenderer = $this->prophesize(Renderer\JsonRenderer::class)->reveal();
-        $xmlRenderer = $this->prophesize(Renderer\XmlRenderer::class)->reveal();
-        $response = $this->prophesize(ResponseInterface::class)->reveal();
+        $jsonRenderer    = $this->prophesize(Renderer\JsonRenderer::class)->reveal();
+        $xmlRenderer     = $this->prophesize(Renderer\XmlRenderer::class)->reveal();
+        $response        = $this->prophesize(ResponseInterface::class)->reveal();
         $responseFactory = function () use ($response) {
             return $response;
         };
@@ -57,19 +59,18 @@ class HalResponseFactoryFactoryTest extends TestCase
         self::assertResponseFactoryReturns($response, $instance);
     }
 
-
-    public function testReturnsHalResponseFactoryInstanceWithoutConfiguredDependencies() : void
+    public function testReturnsHalResponseFactoryInstanceWithoutConfiguredDependencies(): void
     {
-        $response = $this->prophesize(ResponseInterface::class)->reveal();
+        $response        = $this->prophesize(ResponseInterface::class)->reveal();
         $responseFactory = function () use ($response) {
             return $response;
         };
-        $container = $this->prophesize(ContainerInterface::class);
+        $container       = $this->prophesize(ContainerInterface::class);
         $container->get(ResponseInterface::class)->willReturn($responseFactory);
         $container->has(Renderer\JsonRenderer::class)->willReturn(false);
-        $container->has(\Zend\Expressive\Hal\Renderer\JsonRenderer::class)->willReturn(false);
+        $container->has(JsonRenderer::class)->willReturn(false);
         $container->has(Renderer\XmlRenderer::class)->willReturn(false);
-        $container->has(\Zend\Expressive\Hal\Renderer\XmlRenderer::class)->willReturn(false);
+        $container->has(XmlRenderer::class)->willReturn(false);
 
         $instance = (new HalResponseFactoryFactory())($container->reveal());
         self::assertInstanceOf(HalResponseFactory::class, $instance);
@@ -80,13 +81,13 @@ class HalResponseFactoryFactoryTest extends TestCase
 
     public function testReturnsHalResponseFactoryInstanceWhenResponseInterfaceReturnsFactory()
     {
-        $jsonRenderer = $this->prophesize(Renderer\JsonRenderer::class)->reveal();
-        $xmlRenderer = $this->prophesize(Renderer\XmlRenderer::class)->reveal();
-        $response = $this->prophesize(ResponseInterface::class)->reveal();
+        $jsonRenderer    = $this->prophesize(Renderer\JsonRenderer::class)->reveal();
+        $xmlRenderer     = $this->prophesize(Renderer\XmlRenderer::class)->reveal();
+        $response        = $this->prophesize(ResponseInterface::class)->reveal();
         $responseFactory = function () use ($response) {
             return $response;
         };
-        $stream = new class()
+        $stream          = new class ()
         {
             public function __invoke()
             {

--- a/test/HalResponseFactoryTest.php
+++ b/test/HalResponseFactoryTest.php
@@ -21,9 +21,8 @@ use function strstr;
 
 class HalResponseFactoryTest extends TestCase
 {
-    use TestAsset;
-
     use ProphecyTrait;
+    use TestAsset;
 
     public function setUp(): void
     {
@@ -59,7 +58,10 @@ class HalResponseFactoryTest extends TestCase
         $this->assertSame($this->response->reveal(), $response);
     }
 
-    public function jsonAcceptHeaders()
+    /**
+     * @psalm-return array<string, array{0: string}>
+     */
+    public function jsonAcceptHeaders(): array
     {
         return [
             'application/json'             => ['application/json'],
@@ -90,7 +92,10 @@ class HalResponseFactoryTest extends TestCase
         $this->assertSame($this->response->reveal(), $response);
     }
 
-    public function xmlAcceptHeaders()
+    /**
+     * @psalm-return array<string, array{0: string}>
+     */
+    public function xmlAcceptHeaders(): array
     {
         return [
             'application/xml'             => ['application/xml'],
@@ -122,7 +127,10 @@ class HalResponseFactoryTest extends TestCase
         $this->assertSame($this->response->reveal(), $response);
     }
 
-    public function customMediaTypes()
+    /**
+     * @psalm-return array<string, array{0: string, 1: string, 2: string, 3: string}>
+     */
+    public function customMediaTypes(): array
     {
         // @codingStandardsIgnoreStart
         return [
@@ -143,11 +151,11 @@ class HalResponseFactoryTest extends TestCase
     ) {
         $resource = $this->createExampleResource();
         switch (true) {
-            case (strstr($header, 'json')):
+            case strstr($header, 'json'):
                 $this->jsonRenderer->render($resource)->willReturn($responseBody);
                 $this->xmlRenderer->render($resource)->shouldNotBeCalled();
                 break;
-            case (strstr($header, 'xml')):
+            case strstr($header, 'xml'):
                 $this->xmlRenderer->render($resource)->willReturn($responseBody);
                 $this->jsonRenderer->render($resource)->shouldNotBeCalled();
                 // fall-through

--- a/test/LinkGenerator/MezzioUrlGeneratorFactoryTest.php
+++ b/test/LinkGenerator/MezzioUrlGeneratorFactoryTest.php
@@ -55,7 +55,7 @@ class MezzioUrlGeneratorFactoryTest extends TestCase
         $this->container->get(ServerUrlHelper::class)->shouldNotBeCalled();
         $this->container->get(\Zend\Expressive\Helper\ServerUrlHelper::class)->shouldNotBeCalled();
 
-        $factory = new MezzioUrlGeneratorFactory();
+        $factory   = new MezzioUrlGeneratorFactory();
         $generator = $factory($this->container->reveal());
 
         $this->assertInstanceOf(MezzioUrlGenerator::class, $generator);
@@ -64,7 +64,7 @@ class MezzioUrlGeneratorFactoryTest extends TestCase
 
     public function testFactoryCanCreateUrlGeneratorWithBothUrlHelperAndServerUrlHelper()
     {
-        $urlHelper = $this->prophesize(UrlHelper::class)->reveal();
+        $urlHelper       = $this->prophesize(UrlHelper::class)->reveal();
         $serverUrlHelper = $this->prophesize(ServerUrlHelper::class)->reveal();
 
         $this->container->has(UrlHelper::class)->willReturn(true);
@@ -72,7 +72,7 @@ class MezzioUrlGeneratorFactoryTest extends TestCase
         $this->container->has(ServerUrlHelper::class)->willReturn(true);
         $this->container->get(ServerUrlHelper::class)->willReturn($serverUrlHelper);
 
-        $factory = new MezzioUrlGeneratorFactory();
+        $factory   = new MezzioUrlGeneratorFactory();
         $generator = $factory($this->container->reveal());
 
         $this->assertInstanceOf(MezzioUrlGenerator::class, $generator);
@@ -89,7 +89,7 @@ class MezzioUrlGeneratorFactoryTest extends TestCase
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->has(\Zend\Expressive\Helper\ServerUrlHelper::class)->willReturn(false);
 
-        $factory = new MezzioUrlGeneratorFactory(CustomUrlHelper::class);
+        $factory   = new MezzioUrlGeneratorFactory(CustomUrlHelper::class);
         $generator = $factory($this->container->reveal());
 
         $this->assertInstanceOf(MezzioUrlGenerator::class, $generator);

--- a/test/LinkGeneratorFactoryTest.php
+++ b/test/LinkGeneratorFactoryTest.php
@@ -22,7 +22,7 @@ class LinkGeneratorFactoryTest extends TestCase
 
     use ProphecyTrait;
 
-    public function testReturnsLinkGeneratorInstance() : void
+    public function testReturnsLinkGeneratorInstance(): void
     {
         $urlGenerator = $this->prophesize(LinkGenerator\UrlGeneratorInterface::class)->reveal();
 

--- a/test/LinkTest.php
+++ b/test/LinkTest.php
@@ -8,6 +8,7 @@
 
 namespace MezzioTest\Hal;
 
+use ArgumentCountError;
 use InvalidArgumentException;
 use Mezzio\Hal\Link;
 use PHPUnit\Framework\TestCase;
@@ -17,7 +18,7 @@ class LinkTest extends TestCase
 {
     public function testRequiresRelation()
     {
-        $this->expectException(\ArgumentCountError::class);
+        $this->expectException(ArgumentCountError::class);
         $link = new Link();
     }
 
@@ -67,7 +68,10 @@ class LinkTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $link->getAttributes());
     }
 
-    public function invalidRelations()
+    /**
+     * @psalm-return array<string, array{0: mixed}>
+     */
+    public function invalidRelations(): array
     {
         return [
             'null'         => [null],
@@ -85,6 +89,7 @@ class LinkTest extends TestCase
 
     /**
      * @dataProvider invalidRelations
+     * @param mixed $rel
      */
     public function testWithRelRaisesExceptionForInvalidRelation($rel)
     {
@@ -111,6 +116,7 @@ class LinkTest extends TestCase
 
     /**
      * @dataProvider invalidRelations
+     * @param mixed $rel
      */
     public function testWithoutRelReturnsSameInstanceIfRelationIsInvalid($rel)
     {
@@ -135,7 +141,10 @@ class LinkTest extends TestCase
         $this->assertEquals(['self'], $new->getRels());
     }
 
-    public function invalidUriTypes()
+    /**
+     * @psalm-return array<string, array{0: mixed}>
+     */
+    public function invalidUriTypes(): array
     {
         return [
             'null'         => [null],
@@ -152,6 +161,7 @@ class LinkTest extends TestCase
 
     /**
      * @dataProvider invalidUriTypes
+     * @param mixed $uri
      */
     public function testWithHrefRaisesExceptionForInvalidUriType($uri)
     {
@@ -160,7 +170,10 @@ class LinkTest extends TestCase
         $link->withHref($uri);
     }
 
-    public function validUriTypes()
+    /**
+     * @psalm-return iterable<string, array{0: string|object}>
+     */
+    public function validUriTypes(): iterable
     {
         yield 'string' => ['https://example.com/api/link'];
         yield 'castable-object' => [new TestAsset\Uri('https://example.com/api/link')];
@@ -168,17 +181,21 @@ class LinkTest extends TestCase
 
     /**
      * @dataProvider validUriTypes
+     * @param string|object $uri
      */
     public function testWithHrefReturnsNewInstanceWhenUriIsValid($uri)
     {
         $link = new Link('self', 'https://example.com');
-        $new = $link->withHref($uri);
+        $new  = $link->withHref($uri);
         $this->assertNotSame($link, $new);
         $this->assertNotEquals((string) $uri, $link->getHref());
         $this->assertEquals((string) $uri, $new->getHref());
     }
 
-    public function invalidAttributeNames()
+    /**
+     * @psalm-return array<string, array{0: mixed}>
+     */
+    public function invalidAttributeNames(): array
     {
         return [
             'null'         => [null],
@@ -196,6 +213,7 @@ class LinkTest extends TestCase
 
     /**
      * @dataProvider invalidAttributeNames
+     * @param mixed $name
      */
     public function testWithAttributeRaisesExceptionForInvalidAttributeName($name)
     {
@@ -205,16 +223,20 @@ class LinkTest extends TestCase
         $link->withAttribute($name, 'foo');
     }
 
-    public function invalidAttributeValues()
+    /**
+     * @psalm-return array<string, array{0: mixed}>
+     */
+    public function invalidAttributeValues(): array
     {
         return [
             'array-with-non-string-values' => [[null, false, true, 0, 0.0, 1, 1.1, 'foo']],
-            'object' => [(object) ['name' => 'attribute']],
+            'object'                       => [(object) ['name' => 'attribute']],
         ];
     }
 
     /**
      * @dataProvider invalidAttributeValues
+     * @param mixed $value
      */
     public function testWithAttributeRaisesExceptionForInvalidAttributeValue($value)
     {
@@ -224,7 +246,10 @@ class LinkTest extends TestCase
         $link->withAttribute('foo', $value);
     }
 
-    public function validAttributes()
+    /**
+     * @psalm-return array<string, array{0: string, 1: mixed}>
+     */
+    public function validAttributes(): array
     {
         return [
             'false'      => ['foo', false],
@@ -240,11 +265,12 @@ class LinkTest extends TestCase
 
     /**
      * @dataProvider validAttributes
+     * @param mixed $value
      */
-    public function testWithAttributeReturnsNewInstanceForValidAttribute($name, $value)
+    public function testWithAttributeReturnsNewInstanceForValidAttribute(string $name, $value)
     {
         $link = new Link('self');
-        $new = $link->withAttribute($name, $value);
+        $new  = $link->withAttribute($name, $value);
         $this->assertNotSame($link, $new);
         $this->assertEquals([], $link->getAttributes());
         $this->assertEquals([$name => $value], $new->getAttributes());
@@ -252,25 +278,26 @@ class LinkTest extends TestCase
 
     /**
      * @dataProvider invalidAttributeNames
+     * @param mixed $name
      */
     public function testWithoutAttributeReturnsSameInstanceWhenAttributeNameIsInvalid($name)
     {
         $link = new Link('self');
-        $new = $link->withoutAttribute($name);
+        $new  = $link->withoutAttribute($name);
         $this->assertSame($link, $new);
     }
 
     public function testWithoutAttributeReturnsSameInstanceWhenAttributeIsNotPresent()
     {
         $link = new Link('self', '', false, ['foo' => 'bar']);
-        $new = $link->withoutAttribute('bar');
+        $new  = $link->withoutAttribute('bar');
         $this->assertSame($link, $new);
     }
 
     public function testWithoutAttributeReturnsNewInstanceWhenAttributeCanBeRemoved()
     {
         $link = new Link('self', '', false, ['foo' => 'bar']);
-        $new = $link->withoutAttribute('foo');
+        $new  = $link->withoutAttribute('foo');
         $this->assertNotSame($link, $new);
         $this->assertEquals(['foo' => 'bar'], $link->getAttributes());
         $this->assertEquals([], $new->getAttributes());

--- a/test/Metadata/ExceptionTest.php
+++ b/test/Metadata/ExceptionTest.php
@@ -23,12 +23,12 @@ use function substr;
 
 class ExceptionTest extends TestCase
 {
-    public function testExceptionInterfaceExtendsHalExceptionInterface() : void
+    public function testExceptionInterfaceExtendsHalExceptionInterface(): void
     {
         self::assertTrue(is_a(ExceptionInterface::class, HalExceptionInterface::class, true));
     }
 
-    public function exception() : Generator
+    public function exception(): Generator
     {
         $namespace = substr(ExceptionInterface::class, 0, strrpos(ExceptionInterface::class, '\\') + 1);
 
@@ -43,7 +43,7 @@ class ExceptionTest extends TestCase
     /**
      * @dataProvider exception
      */
-    public function testExceptionIsInstanceOfExceptionInterface(string $exception) : void
+    public function testExceptionIsInstanceOfExceptionInterface(string $exception): void
     {
         self::assertStringContainsString('Exception', $exception);
         self::assertTrue(is_a($exception, ExceptionInterface::class, true));

--- a/test/Metadata/MetadataMapFactoryTest.php
+++ b/test/Metadata/MetadataMapFactoryTest.php
@@ -35,20 +35,16 @@ class MetadataMapFactoryTest extends TestCase
 
     use ProphecyTrait;
 
-    /**
-     * @var MetadataMapFactory
-     */
+    /** @var MetadataMapFactory */
     private $factory;
 
-    /**
-     * @var ObjectProphecy|ContainerInterface
-     */
+    /** @var ObjectProphecy|ContainerInterface */
     private $container;
 
     public function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
-        $this->factory = new MetadataMapFactory();
+        $this->factory   = new MetadataMapFactory();
     }
 
     public function testFactoryReturnsEmptyMetadataMapWhenNoConfigServicePresent()
@@ -98,9 +94,13 @@ class MetadataMapFactoryTest extends TestCase
     public function testFactoryRaisesExceptionIfTheMetadataClassDoesNotExist()
     {
         $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn([MetadataMap::class => [[
-            '__class__' => 'not-a-class',
-        ]]]);
+        $this->container->get('config')->willReturn([
+            MetadataMap::class => [
+                [
+                    '__class__' => 'not-a-class',
+                ],
+            ],
+        ]);
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage('Invalid metadata class provided');
         ($this->factory)($this->container->reveal());
@@ -109,9 +109,13 @@ class MetadataMapFactoryTest extends TestCase
     public function testFactoryRaisesExceptionIfTheMetadataClassIsNotAnAbstractMetadataType()
     {
         $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn([MetadataMap::class => [[
-            '__class__' => __CLASS__,
-        ]]]);
+        $this->container->get('config')->willReturn([
+            MetadataMap::class => [
+                [
+                    '__class__' => self::class,
+                ],
+            ],
+        ]);
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage('does not extend ' . Metadata\AbstractMetadata::class);
         ($this->factory)($this->container->reveal());
@@ -120,9 +124,13 @@ class MetadataMapFactoryTest extends TestCase
     public function testFactoryRaisesExceptionIfMetadataClassDoesNotHaveACreationMethodInTheFactory()
     {
         $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn([MetadataMap::class => [[
-            '__class__' => TestAsset\TestMetadata::class,
-        ]]]);
+        $this->container->get('config')->willReturn([
+            MetadataMap::class => [
+                [
+                    '__class__' => TestAsset\TestMetadata::class,
+                ],
+            ],
+        ]);
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage('please provide a factory in your configuration');
         ($this->factory)($this->container->reveal());
@@ -134,9 +142,9 @@ class MetadataMapFactoryTest extends TestCase
         $this->container->get('config')->willReturn(
             [
                 MetadataMap::class => [
-                    ['__class__' => TestAsset\TestMetadata::class]
+                    ['__class__' => TestAsset\TestMetadata::class],
                 ],
-                'mezzio-hal' => [
+                'mezzio-hal'       => [
                     'metadata-factories' => [
                         TestAsset\TestMetadata::class => stdClass::class,
                     ],
@@ -148,7 +156,7 @@ class MetadataMapFactoryTest extends TestCase
         ($this->factory)($this->container->reveal());
     }
 
-    public function invalidMetadata() : Generator
+    public function invalidMetadata(): Generator
     {
         $types = [
             UrlBasedResourceMetadata::class,
@@ -173,11 +181,10 @@ class MetadataMapFactoryTest extends TestCase
         $this->container->get('config')->willReturn(
             [
                 MetadataMap::class => [$metadata],
-                'mezzio-hal' => [
+                'mezzio-hal'       => [
                     'metadata-factories' => [
                         RouteBasedCollectionMetadata::class => RouteBasedCollectionMetadataFactory::class,
                         RouteBasedResourceMetadata::class   => RouteBasedResourceMetadataFactory::class,
-
                         UrlBasedCollectionMetadata::class   => UrlBasedCollectionMetadataFactory::class,
                         UrlBasedResourceMetadata::class     => UrlBasedResourceMetadataFactory::class,
                     ],
@@ -202,7 +209,7 @@ class MetadataMapFactoryTest extends TestCase
                         'extractor'      => 'ObjectProperty',
                     ],
                 ],
-                'mezzio-hal' => [
+                'mezzio-hal'       => [
                     'metadata-factories' => [
                         UrlBasedResourceMetadata::class => UrlBasedResourceMetadataFactory::class,
                     ],
@@ -236,7 +243,7 @@ class MetadataMapFactoryTest extends TestCase
                         'pagination_param_type' => Metadata\AbstractCollectionMetadata::TYPE_PLACEHOLDER,
                     ],
                 ],
-                'mezzio-hal' => [
+                'mezzio-hal'       => [
                     'metadata-factories' => [
                         UrlBasedCollectionMetadata::class => UrlBasedCollectionMetadataFactory::class,
                     ],
@@ -264,19 +271,19 @@ class MetadataMapFactoryTest extends TestCase
             [
                 MetadataMap::class => [
                     [
-                        '__class__'                    => RouteBasedResourceMetadata::class,
-                        'resource_class'               => stdClass::class,
-                        'route'                        => 'foo',
-                        'extractor'                    => 'ObjectProperty',
-                        'resource_identifier'          => 'foo_id',
-                        'route_params'                 => ['foo' => 'bar'],
+                        '__class__'                           => RouteBasedResourceMetadata::class,
+                        'resource_class'                      => stdClass::class,
+                        'route'                               => 'foo',
+                        'extractor'                           => 'ObjectProperty',
+                        'resource_identifier'                 => 'foo_id',
+                        'route_params'                        => ['foo' => 'bar'],
                         'identifiers_to_placeholders_mapping' => [
                             'bar' => 'bar_value',
                             'baz' => 'baz_value',
                         ],
                     ],
                 ],
-                'mezzio-hal' => [
+                'mezzio-hal'       => [
                     'metadata-factories' => [
                         RouteBasedResourceMetadata::class => RouteBasedResourceMetadataFactory::class,
                     ],
@@ -296,8 +303,8 @@ class MetadataMapFactoryTest extends TestCase
         $this->assertSame('foo_id', $metadata->getResourceIdentifier());
         $this->assertSame(['foo' => 'bar'], $metadata->getRouteParams());
         $this->assertSame([
-            'bar'    => 'bar_value',
-            'baz'    => 'baz_value',
+            'bar' => 'bar_value',
+            'baz' => 'baz_value',
         ], $metadata->getIdentifiersToPlaceholdersMapping());
     }
 
@@ -318,7 +325,7 @@ class MetadataMapFactoryTest extends TestCase
                         'query_string_arguments' => ['baz' => 'bat'],
                     ],
                 ],
-                'mezzio-hal' => [
+                'mezzio-hal'       => [
                     'metadata-factories' => [
                         RouteBasedCollectionMetadata::class => RouteBasedCollectionMetadataFactory::class,
                     ],

--- a/test/Metadata/MetadataMapTest.php
+++ b/test/Metadata/MetadataMapTest.php
@@ -11,11 +11,13 @@ namespace MezzioTest\Hal\Metadata;
 use Mezzio\Hal\Metadata;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 
 class MetadataMapTest extends TestCase
 {
     use ProphecyTrait;
 
+    /** @psalm-var string[] */
     private $metadataClasses = [
         Metadata\AbstractMetadata::class,
         Metadata\AbstractCollectionMetadata::class,
@@ -31,7 +33,10 @@ class MetadataMapTest extends TestCase
         $this->map = new Metadata\MetadataMap();
     }
 
-    public function validMetadataTypes()
+    /**
+     * @psalm-return iterable<string, Metadata\AbstractMetadata&ObjectProphecy>
+     */
+    public function validMetadataTypes(): iterable
     {
         foreach ($this->metadataClasses as $class) {
             $metadata = $this->prophesize($class);
@@ -64,23 +69,23 @@ class MetadataMapTest extends TestCase
     public function testAddWillRaiseDuplicateMetadataExceptionWhenDuplicateMetadataEncountered()
     {
         $first = $this->prophesize(Metadata\AbstractMetadata::class);
-        $first->getClass()->willReturn(__CLASS__);
+        $first->getClass()->willReturn(self::class);
 
         $this->map->add($first->reveal());
-        $this->assertSame($first->reveal(), $this->map->get(__CLASS__));
+        $this->assertSame($first->reveal(), $this->map->get(self::class));
 
         $second = $this->prophesize(Metadata\AbstractMetadata::class);
-        $second->getClass()->willReturn(__CLASS__);
+        $second->getClass()->willReturn(self::class);
 
         $this->expectException(Metadata\Exception\DuplicateMetadataException::class);
-        $this->expectExceptionMessage(__CLASS__);
+        $this->expectExceptionMessage(self::class);
         $this->map->add($second->reveal());
     }
 
     public function testGetWilRaiseUndefinedMetadataExceptionIfClassNotPresentInMap()
     {
         $this->expectException(Metadata\Exception\UndefinedMetadataException::class);
-        $this->expectExceptionMessage(__CLASS__);
-        $this->map->get(__CLASS__);
+        $this->expectExceptionMessage(self::class);
+        $this->map->get(self::class);
     }
 }

--- a/test/Renderer/TestAsset.php
+++ b/test/Renderer/TestAsset.php
@@ -11,15 +11,16 @@ namespace MezzioTest\Hal\Renderer;
 use Mezzio\Hal\HalResource;
 use Mezzio\Hal\Link;
 
+// phpcs:ignore WebimpressCodingStandard.NamingConventions.Trait.Suffix
 trait TestAsset
 {
-    public function createExampleResource() : HalResource
+    public function createExampleResource(): HalResource
     {
         $resource = new HalResource([
             'id'      => 'XXXX-YYYY-ZZZZ-ABAB',
             'example' => true,
             'foo'     => 'bar',
-            'list'     => [1, 2, 3]
+            'list'    => [1, 2, 3],
         ]);
         $resource = $resource->withLink(new Link('self', '/example/XXXX-YYYY-ZZZZ-ABAB'));
         $resource = $resource->withLink(new Link('shift', '/example/XXXX-YYYY-ZZZZ-ABAB/shift'));
@@ -34,12 +35,12 @@ trait TestAsset
 
         $baz = [];
         for ($i = 0; $i < 3; $i += 1) {
-            $temp = new HalResource([
-                'id' => 'XXXX-' . $i,
+            $temp  = new HalResource([
+                'id'  => 'XXXX-' . $i,
                 'baz' => true,
             ]);
-            $temp = $temp->withLink(new Link('self', '/baz/XXXX-' . $i));
-            $temp = $temp->withLink(new Link('doc', '/doc/baz'));
+            $temp  = $temp->withLink(new Link('self', '/baz/XXXX-' . $i));
+            $temp  = $temp->withLink(new Link('doc', '/doc/baz'));
             $baz[] = $temp;
         }
 

--- a/test/Renderer/XmlRendererTest.php
+++ b/test/Renderer/XmlRendererTest.php
@@ -19,42 +19,42 @@ class XmlRendererTest extends TestCase
 {
     use TestAsset;
 
-    public function createExampleXmlPayload()
+    public function createExampleXmlPayload(): string
     {
         // Closing tag causes syntax highlighting to fail everwhere
-        $xml = '<?xml version="1.0" encoding="UTF-8"?' . ">\n";
-        $xml .= <<< 'EOX'
-<resource rel="self" href="/example/XXXX-YYYY-ZZZZ-ABAB">
-  <link rel="shift" href="/example/XXXX-YYYY-ZZZZ-ABAB/shift"/>
-  <resource rel="bar" href="/bar/BABA-ZZZZ-YYYY-XXXX">
-    <link rel="doc" href="/doc/bar"/>
-    <id>BABA-ZZZZ-YYYY-XXXX</id>
-    <bar>true</bar>
-    <some>data</some>
-  </resource>
-  <resource rel="baz" href="/baz/XXXX-0">
-    <link rel="doc" href="/doc/baz"/>
-    <id>XXXX-0</id>
-    <baz>true</baz>
-  </resource>
-  <resource rel="baz" href="/baz/XXXX-1">
-    <link rel="doc" href="/doc/baz"/>
-    <id>XXXX-1</id>
-    <baz>true</baz>
-  </resource>
-  <resource rel="baz" href="/baz/XXXX-2">
-    <link rel="doc" href="/doc/baz"/>
-    <id>XXXX-2</id>
-    <baz>true</baz>
-  </resource>
-  <id>XXXX-YYYY-ZZZZ-ABAB</id>
-  <example>true</example>
-  <foo>bar</foo>
-  <list>1</list>
-  <list>2</list>
-  <list>3</list>
-</resource>
-EOX;
+        $xml  = '<?xml version="1.0" encoding="UTF-8"?' . ">\n";
+        $xml .= <<<'EOX'
+            <resource rel="self" href="/example/XXXX-YYYY-ZZZZ-ABAB">
+              <link rel="shift" href="/example/XXXX-YYYY-ZZZZ-ABAB/shift"/>
+              <resource rel="bar" href="/bar/BABA-ZZZZ-YYYY-XXXX">
+                <link rel="doc" href="/doc/bar"/>
+                <id>BABA-ZZZZ-YYYY-XXXX</id>
+                <bar>true</bar>
+                <some>data</some>
+              </resource>
+              <resource rel="baz" href="/baz/XXXX-0">
+                <link rel="doc" href="/doc/baz"/>
+                <id>XXXX-0</id>
+                <baz>true</baz>
+              </resource>
+              <resource rel="baz" href="/baz/XXXX-1">
+                <link rel="doc" href="/doc/baz"/>
+                <id>XXXX-1</id>
+                <baz>true</baz>
+              </resource>
+              <resource rel="baz" href="/baz/XXXX-2">
+                <link rel="doc" href="/doc/baz"/>
+                <id>XXXX-2</id>
+                <baz>true</baz>
+              </resource>
+              <id>XXXX-YYYY-ZZZZ-ABAB</id>
+              <example>true</example>
+              <foo>bar</foo>
+              <list>1</list>
+              <list>2</list>
+              <list>3</list>
+            </resource>
+            EOX;
         return $xml;
     }
 
@@ -79,7 +79,7 @@ EOX;
         $resource = $resource->withLink(new Link('self', '/example'));
 
         $renderer = new XmlRenderer();
-        $xml = $renderer->render($resource);
+        $xml      = $renderer->render($resource);
         $this->assertStringContainsString($dateTime->format('c'), $xml);
     }
 
@@ -93,7 +93,7 @@ EOX;
         $resource = $resource->withLink(new Link('self', '/example'));
 
         $renderer = new XmlRenderer();
-        $xml = $renderer->render($resource);
+        $xml      = $renderer->render($resource);
         $this->assertStringContainsString((string) $instance, $xml);
     }
 
@@ -105,7 +105,7 @@ EOX;
         $resource = $resource->withLink(new Link('self', '/example'));
 
         $renderer = new XmlRenderer();
-        $xml = $renderer->render($resource);
+        $xml      = $renderer->render($resource);
         $this->assertStringContainsString('<key/>', $xml);
     }
 }

--- a/test/ResourceGenerator/DoctrinePaginatorTest.php
+++ b/test/ResourceGenerator/DoctrinePaginatorTest.php
@@ -23,6 +23,9 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ServerRequestInterface;
 
+use function array_map;
+use function range;
+
 class DoctrinePaginatorTest extends TestCase
 {
     use ProphecyTrait;
@@ -35,10 +38,10 @@ class DoctrinePaginatorTest extends TestCase
         $this->request       = $this->prophesize(ServerRequestInterface::class);
         $this->paginator     = $this->prophesize(Paginator::class);
 
-        $this->strategy      = new RouteBasedCollectionStrategy();
+        $this->strategy = new RouteBasedCollectionStrategy();
     }
 
-    public function mockQuery()
+    public function mockQuery(): AbstractQuery
     {
         return $this->getMockBuilder(AbstractQuery::class)
             ->disableOriginalConstructor()
@@ -60,7 +63,7 @@ class DoctrinePaginatorTest extends TestCase
             ->willReturn($link);
     }
 
-    public function invalidPageCombinations() : iterable
+    public function invalidPageCombinations(): iterable
     {
         yield 'negative'   => [-1, 100];
         yield 'zero'       => [0, 100];

--- a/test/ResourceGenerator/ExceptionTest.php
+++ b/test/ResourceGenerator/ExceptionTest.php
@@ -23,12 +23,12 @@ use function substr;
 
 class ExceptionTest extends TestCase
 {
-    public function testExceptionInterfaceExtendsHalExceptionInterface() : void
+    public function testExceptionInterfaceExtendsHalExceptionInterface(): void
     {
         self::assertTrue(is_a(ExceptionInterface::class, HalExceptionInterface::class, true));
     }
 
-    public function exception() : Generator
+    public function exception(): Generator
     {
         $namespace = substr(ExceptionInterface::class, 0, strrpos(ExceptionInterface::class, '\\') + 1);
 
@@ -43,7 +43,7 @@ class ExceptionTest extends TestCase
     /**
      * @dataProvider exception
      */
-    public function testExceptionIsInstanceOfExceptionInterface(string $exception) : void
+    public function testExceptionIsInstanceOfExceptionInterface(string $exception): void
     {
         self::assertStringContainsString('Exception', $exception);
         self::assertTrue(is_a($exception, ExceptionInterface::class, true));

--- a/test/ResourceGenerator/NestedCollectionResourceGenerationTest.php
+++ b/test/ResourceGenerator/NestedCollectionResourceGenerationTest.php
@@ -21,9 +21,11 @@ use MezzioTest\Hal\TestAsset;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+use function array_key_exists;
 use function array_shift;
 
 class NestedCollectionResourceGenerationTest extends TestCase
@@ -36,15 +38,15 @@ class NestedCollectionResourceGenerationTest extends TestCase
 
     public function testNestedCollectionIsEmbeddedAsAnArrayNotAHalCollection()
     {
-        $collection = $this->createCollection();
-        $foo = new TestAsset\FooBar;
-        $foo->id = 101010;
-        $foo->foo = 'foo';
+        $collection    = $this->createCollection();
+        $foo           = new TestAsset\FooBar();
+        $foo->id       = 101010;
+        $foo->foo      = 'foo';
         $foo->children = $collection;
 
-        $request = $this->prophesize(ServerRequestInterface::class);
-        $metadataMap = $this->createMetadataMap();
-        $hydrators = $this->createHydrators();
+        $request       = $this->prophesize(ServerRequestInterface::class);
+        $metadataMap   = $this->createMetadataMap();
+        $hydrators     = $this->createHydrators();
         $linkGenerator = $this->createLinkGenerator($request);
 
         $generator = new ResourceGenerator(
@@ -79,18 +81,22 @@ class NestedCollectionResourceGenerationTest extends TestCase
         }
     }
 
-    private function createCollection() : TestAsset\Collection
+    private function createCollection(): TestAsset\Collection
     {
         $items = [];
         for ($i = 1; $i < 11; $i += 1) {
-            $item = new TestAsset\Child;
-            $item->id = $i;
+            $item          = new TestAsset\Child();
+            $item->id      = $i;
             $item->message = 'ack';
-            $items[] = $item;
+            $items[]       = $item;
         }
         return new TestAsset\Collection($items);
     }
 
+    /**
+     * @return MetadataMap|ObjectProphecy
+     * @psalm-return MetadataMap&ObjectProphecy
+     */
     private function createMetadataMap()
     {
         $metadataMap = $this->prophesize(MetadataMap::class);
@@ -125,6 +131,10 @@ class NestedCollectionResourceGenerationTest extends TestCase
         return $metadataMap;
     }
 
+    /**
+     * @return ContainerInterface|ObjectProphecy
+     * @psalm-return ContainerInterface&ObjectProphecy
+     */
     private function createHydrators()
     {
         $hydratorClass = self::getObjectPropertyHydratorClass();
@@ -134,6 +144,12 @@ class NestedCollectionResourceGenerationTest extends TestCase
         return $hydrators;
     }
 
+    /**
+     * @param ServerRequestInterface|ObjectProphecy $request
+     * @psalm-param ServerRequestInterface&ObjectProphecy $request
+     * @return LinkGenerator|ObjectProphecy
+     * @psalm-return LinkGenerator&ObjectProphecy
+     */
     public function createLinkGenerator($request)
     {
         $linkGenerator = $this->prophesize(LinkGenerator::class);

--- a/test/ResourceGenerator/ResourceWithNestedInstancesTest.php
+++ b/test/ResourceGenerator/ResourceWithNestedInstancesTest.php
@@ -20,8 +20,11 @@ use MezzioTest\Hal\TestAsset;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
+
+use function array_key_exists;
 
 class ResourceWithNestedInstancesTest extends TestCase
 {
@@ -31,19 +34,19 @@ class ResourceWithNestedInstancesTest extends TestCase
 
     public function testNestedObjectInMetadataMapIsEmbeddedAsResource()
     {
-        $child = new TestAsset\Child;
-        $child->id = 9876;
+        $child          = new TestAsset\Child();
+        $child->id      = 9876;
         $child->message = 'ack';
 
-        $parent = new TestAsset\FooBar;
-        $parent->id = 1234;
+        $parent      = new TestAsset\FooBar();
+        $parent->id  = 1234;
         $parent->foo = 'FOO';
         $parent->bar = $child;
 
         $request = $this->prophesize(ServerRequestInterface::class);
 
-        $metadataMap = $this->createMetadataMap();
-        $hydrators = $this->createHydrators();
+        $metadataMap   = $this->createMetadataMap();
+        $hydrators     = $this->createHydrators();
         $linkGenerator = $this->createLinkGenerator($request);
 
         $generator = new ResourceGenerator(
@@ -71,6 +74,10 @@ class ResourceWithNestedInstancesTest extends TestCase
         $this->assertEquals($child->message, $childResource->getElement('message'));
     }
 
+    /**
+     * @return MetadataMap|ObjectProphecy
+     * @psalm-return MetadataMap&ObjectProphecy
+     */
     public function createMetadataMap()
     {
         $metadataMap = $this->prophesize(MetadataMap::class);
@@ -96,6 +103,12 @@ class ResourceWithNestedInstancesTest extends TestCase
         return $metadataMap;
     }
 
+    /**
+     * @param ServerRequestInterface|ObjectProphecy $request
+     * @psalm-param ServerRequestInterface&ObjectProphecy $request
+     * @return LinkGenerator|ObjectProphecy
+     * @psalm-return LinkGenerator&ObjectProphecy
+     */
     public function createLinkGenerator($request)
     {
         $linkGenerator = $this->prophesize(LinkGenerator::class);
@@ -127,6 +140,10 @@ class ResourceWithNestedInstancesTest extends TestCase
         return $linkGenerator;
     }
 
+    /**
+     * @return ContainerInterface|ObjectProphecy
+     * @psalm-return ContainerInterface&ObjectProphecy
+     */
     public function createHydrators()
     {
         $hydratorClass = self::getObjectPropertyHydratorClass();

--- a/test/ResourceGenerator/ResourceWithSelfReferringInstanceTest.php
+++ b/test/ResourceGenerator/ResourceWithSelfReferringInstanceTest.php
@@ -20,6 +20,8 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+use function array_key_exists;
+
 final class ResourceWithSelfReferringInstanceTest extends TestCase
 {
     use Assertions;
@@ -27,15 +29,15 @@ final class ResourceWithSelfReferringInstanceTest extends TestCase
 
     public function testSelfReferringIsEmbeddedAsResource(): void
     {
-        $parent = new TestAsset\FooBar;
-        $parent->id = 1234;
+        $parent      = new TestAsset\FooBar();
+        $parent->id  = 1234;
         $parent->foo = 'FOO';
         $parent->bar = $parent;
 
         $request = $this->prophesize(ServerRequestInterface::class);
 
-        $metadataMap = $this->createMetadataMap();
-        $hydrators = $this->createHydrators();
+        $metadataMap   = $this->createMetadataMap();
+        $hydrators     = $this->createHydrators();
         $linkGenerator = $this->createLinkGenerator($request);
 
         $generator = new ResourceGenerator(
@@ -85,8 +87,6 @@ final class ResourceWithSelfReferringInstanceTest extends TestCase
     }
 
     /**
-     * @param ObjectProphecy $request
-     *
      * @return LinkGenerator|ObjectProphecy
      */
     public function createLinkGenerator(ObjectProphecy $request)

--- a/test/ResourceGeneratorFactoryTest.php
+++ b/test/ResourceGeneratorFactoryTest.php
@@ -28,9 +28,7 @@ class ResourceGeneratorFactoryTest extends TestCase
 
     use ProphecyTrait;
 
-    /**
-     * @var ObjectProphecy|ContainerInterface
-     */
+    /** @var ObjectProphecy|ContainerInterface */
     private $container;
 
     public function setUp(): void
@@ -59,31 +57,47 @@ class ResourceGeneratorFactoryTest extends TestCase
         $object($this->container->reveal());
     }
 
-    public function missingOrEmptyStrategiesConfiguration()
+    /**
+     * @psalm-return iterable<
+     *     string,
+     *     array{
+     *         0: array<string, array<string, array<string, array|ArrayObject>>>
+     *     }
+     * >
+     */
+    public function missingOrEmptyStrategiesConfiguration(): iterable
     {
         yield 'missing-top-level' => [[]];
-        yield 'missing-second-level' => [[
-            'mezzio-hal' => [],
-        ]];
-        yield 'missing-third-level' => [[
-            'mezzio-hal' => [
-                'resource-generator' => [],
+        yield 'missing-second-level' => [
+            [
+                'mezzio-hal' => [],
             ],
-        ]];
-        yield 'empty-array' => [[
-            'mezzio-hal' => [
-                'resource-generator' => [
-                    'strategies' => [],
+        ];
+        yield 'missing-third-level' => [
+            [
+                'mezzio-hal' => [
+                    'resource-generator' => [],
                 ],
             ],
-        ]];
-        yield 'empty-array-object' => [[
-            'mezzio-hal' => [
-                'resource-generator' => [
-                    'strategies' => new ArrayObject([]),
+        ];
+        yield 'empty-array' => [
+            [
+                'mezzio-hal' => [
+                    'resource-generator' => [
+                        'strategies' => [],
+                    ],
                 ],
             ],
-        ]];
+        ];
+        yield 'empty-array-object' => [
+            [
+                'mezzio-hal' => [
+                    'resource-generator' => [
+                        'strategies' => new ArrayObject([]),
+                    ],
+                ],
+            ],
+        ];
     }
 
     /**
@@ -101,7 +115,10 @@ class ResourceGeneratorFactoryTest extends TestCase
         self::assertEmpty($resourceGenerator->getStrategies());
     }
 
-    public function invalidStrategiesConfig()
+    /**
+     * @psalm-return iterable<string, array{0: mixed}>
+     */
+    public function invalidStrategiesConfig(): iterable
     {
         yield 'false'      => [false];
         yield 'true'       => [true];

--- a/test/ResourceGeneratorTest.php
+++ b/test/ResourceGeneratorTest.php
@@ -31,6 +31,8 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use stdClass;
 
+use function array_key_exists;
+
 /**
  * @todo Create tests for cases where resources embed other resources.
  */
@@ -42,38 +44,28 @@ class ResourceGeneratorTest extends TestCase
 
     use ProphecyTrait;
 
-    /**
-     * @var ObjectProphecy|ServerRequestInterface
-     */
+    /** @var ObjectProphecy|ServerRequestInterface */
     private $request;
 
-    /**
-     * @var ObjectProphecy|ContainerInterface
-     */
+    /** @var ObjectProphecy|ContainerInterface */
     private $hydrators;
 
-    /**
-     * @var ObjectProphecy|LinkGenerator
-     */
+    /** @var ObjectProphecy|LinkGenerator */
     private $linkGenerator;
 
-    /**
-     * @var ObjectProphecy|Metadata\MetadataMap
-     */
+    /** @var ObjectProphecy|Metadata\MetadataMap */
     private $metadataMap;
 
-    /**
-     * @var ObjectProphecy|ResourceGenerator
-     */
+    /** @var ObjectProphecy|ResourceGenerator */
     private $generator;
 
     public function setUp(): void
     {
-        $this->request = $this->prophesize(ServerRequestInterface::class);
-        $this->hydrators = $this->prophesize(ContainerInterface::class);
+        $this->request       = $this->prophesize(ServerRequestInterface::class);
+        $this->hydrators     = $this->prophesize(ContainerInterface::class);
         $this->linkGenerator = $this->prophesize(LinkGenerator::class);
-        $this->metadataMap = $this->prophesize(Metadata\MetadataMap::class);
-        $this->generator = new ResourceGenerator(
+        $this->metadataMap   = $this->prophesize(Metadata\MetadataMap::class);
+        $this->generator     = new ResourceGenerator(
             $this->metadataMap->reveal(),
             $this->hydrators->reveal(),
             $this->linkGenerator->reveal()
@@ -125,7 +117,7 @@ class ResourceGeneratorTest extends TestCase
 
     public function testCanGenerateUrlBasedResourceFromObjectDefinedInMetadataMap()
     {
-        $instance      = new TestAsset\FooBar;
+        $instance      = new TestAsset\FooBar();
         $instance->id  = 'XXXX-YYYY-ZZZZ';
         $instance->foo = 'BAR';
         $instance->bar = 'BAZ';
@@ -160,7 +152,7 @@ class ResourceGeneratorTest extends TestCase
 
     public function testCanGenerateRouteBasedResourceFromObjectDefinedInMetadataMap()
     {
-        $instance      = new TestAsset\FooBar;
+        $instance      = new TestAsset\FooBar();
         $instance->id  = 'XXXX-YYYY-ZZZZ';
         $instance->foo = 'BAR';
         $instance->bar = 'BAZ';
@@ -210,15 +202,15 @@ class ResourceGeneratorTest extends TestCase
 
     public function testCanGenerateUrlBasedCollectionFromObjectDefinedInMetadataMap()
     {
-        $first      = new TestAsset\FooBar;
+        $first      = new TestAsset\FooBar();
         $first->id  = 'XXXX-YYYY-ZZZZ';
         $first->foo = 'BAR';
         $first->bar = 'BAZ';
 
-        $second = clone $first;
+        $second     = clone $first;
         $second->id = 'XXXX-YYYY-ZZZA';
-        $third = clone $first;
-        $third->id = 'XXXX-YYYY-ZZZB';
+        $third      = clone $first;
+        $third->id  = 'XXXX-YYYY-ZZZB';
 
         $resourceMetadata = new Metadata\UrlBasedResourceMetadata(
             TestAsset\FooBar::class,
@@ -276,7 +268,7 @@ class ResourceGeneratorTest extends TestCase
 
     public function testCanGenerateRouteBasedCollectionFromObjectDefinedInMetadataMap()
     {
-        $instance      = new TestAsset\FooBar;
+        $instance      = new TestAsset\FooBar();
         $instance->foo = 'BAR';
         $instance->bar = 'BAZ';
 
@@ -294,8 +286,8 @@ class ResourceGeneratorTest extends TestCase
 
         $instances = [];
         for ($i = 1; $i < 15; $i += 1) {
-            $next = clone $instance;
-            $next->id = $i;
+            $next        = clone $instance;
+            $next->id    = $i;
             $instances[] = $next;
 
             $this->linkGenerator
@@ -408,7 +400,7 @@ class ResourceGeneratorTest extends TestCase
 
     public function testGeneratedRouteBasedCollectionCastsPaginationMetadataToIntegers()
     {
-        $instance      = new TestAsset\FooBar;
+        $instance      = new TestAsset\FooBar();
         $instance->foo = 'BAR';
         $instance->bar = 'BAZ';
 
@@ -426,8 +418,8 @@ class ResourceGeneratorTest extends TestCase
 
         $instances = [];
         for ($i = 1; $i <= 5; $i += 1) {
-            $next = clone $instance;
-            $next->id = $i;
+            $next        = clone $instance;
+            $next->id    = $i;
             $instances[] = $next;
 
             $this->linkGenerator
@@ -518,7 +510,7 @@ class ResourceGeneratorTest extends TestCase
 
     public function testGeneratorDoesNotAcceptPageQueryOutOfBounds()
     {
-        $instance      = new TestAsset\FooBar;
+        $instance      = new TestAsset\FooBar();
         $instance->foo = 'BAR';
         $instance->bar = 'BAZ';
 
@@ -536,8 +528,8 @@ class ResourceGeneratorTest extends TestCase
 
         $instances = [];
         for ($i = 1; $i < 15; $i += 1) {
-            $next = clone $instance;
-            $next->id = $i;
+            $next        = clone $instance;
+            $next->id    = $i;
             $instances[] = $next;
 
             $this->linkGenerator
@@ -547,7 +539,7 @@ class ResourceGeneratorTest extends TestCase
                     'foo-bar',
                     [
                         'foo_bar_id' => $i,
-                        'test' => 'param',
+                        'test'       => 'param',
                     ]
                 )
                 ->willReturn(new Link('self', '/api/foo-bar/' . $i));
@@ -574,7 +566,7 @@ class ResourceGeneratorTest extends TestCase
 
     public function testGeneratorDoesNotAcceptNegativePageQuery()
     {
-        $instance      = new TestAsset\FooBar;
+        $instance      = new TestAsset\FooBar();
         $instance->foo = 'BAR';
         $instance->bar = 'BAZ';
 
@@ -592,8 +584,8 @@ class ResourceGeneratorTest extends TestCase
 
         $instances = [];
         for ($i = 1; $i < 2; $i += 1) {
-            $next = clone $instance;
-            $next->id = $i;
+            $next        = clone $instance;
+            $next->id    = $i;
             $instances[] = $next;
 
             $this->linkGenerator
@@ -603,7 +595,7 @@ class ResourceGeneratorTest extends TestCase
                     'foo-bar',
                     [
                         'foo_bar_id' => $i,
-                        'test' => 'param',
+                        'test'       => 'param',
                     ]
                 )
                 ->willReturn(new Link('self', '/api/foo-bar/' . $i));
@@ -630,7 +622,7 @@ class ResourceGeneratorTest extends TestCase
 
     public function testGeneratorAcceptsOnePageWhenCollectionHasNoEmbedded()
     {
-        $instance      = new TestAsset\FooBar;
+        $instance      = new TestAsset\FooBar();
         $instance->foo = 'BAR';
         $instance->bar = 'BAZ';
 
@@ -677,22 +669,15 @@ class ResourceGeneratorTest extends TestCase
         $this->assertEquals(0, $resource->getElement('_page_count'));
     }
 
-    public function testGeneratorRaisesExceptionForNonObjectType()
-    {
-        $this->expectException(InvalidObjectException::class);
-        $this->expectExceptionMessage('non-object');
-        $this->generator->fromObject('foo', $this->request->reveal());
-    }
-
     public function testGeneratorRaisesExceptionForUnknownObjectType()
     {
-        $this->metadataMap->has(__CLASS__)->willReturn(false);
+        $this->metadataMap->has(self::class)->willReturn(false);
         $this->expectException(InvalidObjectException::class);
         $this->expectExceptionMessage('not in metadata map');
         $this->generator->fromObject($this, $this->request->reveal());
     }
 
-    public function strategyCollection() : Generator
+    public function strategyCollection(): Generator
     {
         yield 'route-based-collection' => [
             new ResourceGenerator\RouteBasedCollectionStrategy(),
@@ -705,7 +690,7 @@ class ResourceGeneratorTest extends TestCase
         ];
     }
 
-    public function strategyResource() : Generator
+    public function strategyResource(): Generator
     {
         yield 'route-based-resource' => [
             new ResourceGenerator\RouteBasedResourceStrategy(),
@@ -723,11 +708,11 @@ class ResourceGeneratorTest extends TestCase
     public function testUnexpectedMetadataForStrategy(ResourceGenerator\StrategyInterface $strategy)
     {
         $this->generator->addStrategy(
-            TestAsset\TestMetadata::class,
+            TestMetadata::class,
             $strategy
         );
 
-        $collectionMetadata = new TestAsset\TestMetadata();
+        $collectionMetadata = new TestMetadata();
 
         $this->metadataMap->has(TestAsset\FooBar::class)->willReturn(true);
         $this->metadataMap->get(TestAsset\FooBar::class)->willReturn($collectionMetadata);
@@ -778,7 +763,7 @@ class ResourceGeneratorTest extends TestCase
 
     public function testPassesAllScalarEntityPropertiesAsRouteParametersWhenGeneratingUri()
     {
-        $instance      = new TestAsset\FooBar;
+        $instance      = new TestAsset\FooBar();
         $instance->id  = 'XXXX-YYYY-ZZZZ';
         $instance->foo = 'BAR';
         $instance->bar = [
@@ -823,7 +808,7 @@ class ResourceGeneratorTest extends TestCase
 
     public function testUsesConfiguredRoutePlaceholderMapToSpecifyRouteParams()
     {
-        $instance      = new TestAsset\FooBar;
+        $instance      = new TestAsset\FooBar();
         $instance->id  = 'XXXX-YYYY-ZZZZ';
         $instance->foo = 'BAR';
         $instance->bar = 'BAZ';

--- a/test/TestAsset/Child.php
+++ b/test/TestAsset/Child.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable
 
 /**
  * @see       https://github.com/mezzio/mezzio-hal for the canonical source repository

--- a/test/TestAsset/FooBar.php
+++ b/test/TestAsset/FooBar.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable
 
 /**
  * @see       https://github.com/mezzio/mezzio-hal for the canonical source repository

--- a/test/TestAsset/StringSerializable.php
+++ b/test/TestAsset/StringSerializable.php
@@ -12,7 +12,7 @@ namespace MezzioTest\Hal\TestAsset;
 
 class StringSerializable
 {
-    public function __toString()
+    public function __toString(): string
     {
         return __METHOD__;
     }

--- a/test/TestAsset/TestMetadata.php
+++ b/test/TestAsset/TestMetadata.php
@@ -13,7 +13,7 @@ use stdClass;
 
 class TestMetadata extends AbstractMetadata
 {
-    public function getClass() : string
+    public function getClass(): string
     {
         return stdClass::class;
     }

--- a/test/TestAsset/TestMetadataMapFactory.php
+++ b/test/TestAsset/TestMetadataMapFactory.php
@@ -12,7 +12,7 @@ use Mezzio\Hal\Metadata\MetadataMapFactory;
 
 class TestMetadataMapFactory extends MetadataMapFactory
 {
-    protected function createTestMetadata(array $metadata) : TestMetadata
+    protected function createTestMetadata(array $metadata): TestMetadata
     {
         return new TestMetadata();
     }

--- a/test/TestAsset/Uri.php
+++ b/test/TestAsset/Uri.php
@@ -10,6 +10,7 @@ namespace MezzioTest\Hal\TestAsset;
 
 class Uri
 {
+    /** @var strign */
     private $uri;
 
     public function __construct(string $uri)
@@ -17,7 +18,7 @@ class Uri
         $this->uri = $uri;
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->uri;
     }


### PR DESCRIPTION
| Q            | A   |
| ------------ | --- |
| Bug?         | No  |
| Enhancement? | Yes |
| BC Break?    | Yes |

Updates code base to laminas-coding-standard 2.1, and applies rules, fixing all errors.

Adds a number of typehints that were previously omitted:

- `HalResource::jsonSerialize()` now adds an `array` return typehint
- `DuplicateMetadataException::create()` now adds a `self` return typehint
- `UndefinedClassException::create()` adds the `string` typehint to the `$class` argument, and a return typehint of `self`
- `UndefinedMetadataException::create()` adds the `string` typehint to the `$class` argument, and a return typehint of `self`
- `StrategyInterface::fromObject()` adds the `object` typehint to the `$instance` argument.
  This also affects each implementation:
  - `RouteBasedCollectionStrategy`
  - `RouteBasedResourceStrategy`
  - `UrlBasedCollectionStrategy`
  - `UrlBasedResourceStrategy`
