### PR TITLE
Provide Psalm integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ install:
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then XDEBUG_MODE=coverage composer test-coverage ; else composer test ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer static-analysis ; fi
 
 after_script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then vendor/bin/php-coveralls -v ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Versions prior to 0.4.0 were released as the package "weierophinney/hal".
 
 ### Changed
 
+- [#29](https://github.com/mezzio/mezzio-hal/pull/29) makes the following signature changes to the `LinkCollection` class:
+  - `getLinks()` gets an `array` return typehint
+  - `getLinksByRel()` gets an `array` return typehint
+  - `withLink()` gets a `self` return typehint
+  - `withoutLink()` gets a `self` return typehint
+
 - [#28](https://github.com/mezzio/mezzio-hal/pull/28) adds the `object` typehint to the `$instance` argument of the `StrategyInterface::fromObject()` method.
   This also affects each of the shipped implementations:
   - `RouteBasedCollectionStrategy`

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,9 @@
         "laminas/laminas-paginator": "^2.9",
         "mezzio/mezzio-helpers": "^5.4",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "psalm/plugin-phpunit": "^0.15.0",
+        "vimeo/psalm": "^4.3"
     },
     "provide": {
         "psr/link-implementation": "1.0"
@@ -72,6 +74,7 @@
         ],
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
+        "static-analysis": "psalm --shepherd --stats",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -16,17 +16,15 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$new-&gt;embedded</code>
     </InvalidPropertyAssignmentValue>
-    <MissingClosureParamType occurrences="16">
+    <MissingClosureParamType occurrences="14">
       <code>$containsNonLinkItem</code>
       <code>$isResource</code>
-      <code>$item</code>
       <code>$item</code>
       <code>$item</code>
       <code>$key</code>
       <code>$link</code>
       <code>$links</code>
       <code>$matchesCollection</code>
-      <code>$name</code>
       <code>$name</code>
       <code>$name</code>
       <code>$rel</code>
@@ -38,7 +36,7 @@
       <code>function ($item) {</code>
       <code>function (array $byRelation, LinkInterface $link) {</code>
     </MissingClosureReturnType>
-    <MixedArgument occurrences="12">
+    <MixedArgument occurrences="14">
       <code>$byRelation[$rel]</code>
       <code>$byRelation[$rel]</code>
       <code>$item</code>
@@ -51,9 +49,12 @@
       <code>$resource</code>
       <code>$this-&gt;embedded[$name]</code>
       <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion occurrences="2">
       <code>$name</code>
+      <code>$resource</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess occurrences="2">
       <code>$byRelation[$rel]</code>
@@ -67,25 +68,22 @@
       <code>$relations[$key]</code>
       <code>$resource</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="8">
+    <MixedArrayOffset occurrences="7">
       <code>$byRelation[$rel]</code>
       <code>$byRelation[$rel]</code>
       <code>$byRelation[$rel]</code>
       <code>$byRelation[$rel]</code>
-      <code>$embedded[$name]</code>
       <code>$relations[$key]</code>
       <code>$relations[$key]</code>
       <code>$relations[$key]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$collection</code>
       <code>$relations</code>
       <code>$relations[$key]</code>
-      <code>$resource</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
-      <code>?HalResource</code>
+    <MixedInferredReturnType occurrences="1">
       <code>array</code>
     </MixedInferredReturnType>
     <MixedMethodCall occurrences="1">
@@ -96,9 +94,8 @@
       <code>$this-&gt;embedded</code>
       <code>$this-&gt;embedded</code>
     </MixedPropertyTypeCoercion>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement occurrences="1">
       <code>$embedded</code>
-      <code>$resource</code>
     </MixedReturnStatement>
     <MixedReturnTypeCoercion occurrences="3">
       <code>$forceCollection ? [$resource] : $resource</code>
@@ -197,20 +194,12 @@
   </file>
   <file src="src/LinkCollection.php">
     <LessSpecificImplementedReturnType occurrences="2">
-      <code>HalResource</code>
-      <code>HalResource</code>
+      <code>self</code>
+      <code>self</code>
     </LessSpecificImplementedReturnType>
-    <MismatchingDocblockReturnType occurrences="2">
-      <code>HalResource</code>
-      <code>HalResource</code>
-    </MismatchingDocblockReturnType>
     <MissingParamType occurrences="1">
       <code>$rel</code>
     </MissingParamType>
-    <MixedInferredReturnType occurrences="2">
-      <code>HalResource</code>
-      <code>HalResource</code>
-    </MixedInferredReturnType>
   </file>
   <file src="src/LinkGenerator/MezzioUrlGeneratorFactory.php">
     <MixedArgument occurrences="3">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,1459 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.3.1@2feba22a005a18bf31d4c7b9bdb9252c73897476">
+  <file src="src/ConfigProvider.php">
+    <UndefinedClass occurrences="4">
+      <code>\Zend\Expressive\Hal\RouteBasedCollectionStrategy</code>
+      <code>\Zend\Expressive\Hal\RouteBasedResourceStrategy</code>
+      <code>\Zend\Expressive\Hal\UrlBasedCollectionStrategy</code>
+      <code>\Zend\Expressive\Hal\UrlBasedResourceStrategy</code>
+    </UndefinedClass>
+  </file>
+  <file src="src/HalResource.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>$this-&gt;embedded[$name]</code>
+      <code>is_object($resource)</code>
+    </DocblockTypeContradiction>
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$new-&gt;embedded</code>
+    </InvalidPropertyAssignmentValue>
+    <MissingClosureParamType occurrences="16">
+      <code>$containsNonLinkItem</code>
+      <code>$isResource</code>
+      <code>$item</code>
+      <code>$item</code>
+      <code>$item</code>
+      <code>$key</code>
+      <code>$link</code>
+      <code>$links</code>
+      <code>$matchesCollection</code>
+      <code>$name</code>
+      <code>$name</code>
+      <code>$name</code>
+      <code>$rel</code>
+      <code>$resource</code>
+      <code>$resource</code>
+      <code>$value</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="2">
+      <code>function ($item) {</code>
+      <code>function (array $byRelation, LinkInterface $link) {</code>
+    </MissingClosureReturnType>
+    <MixedArgument occurrences="12">
+      <code>$byRelation[$rel]</code>
+      <code>$byRelation[$rel]</code>
+      <code>$item</code>
+      <code>$links</code>
+      <code>$links</code>
+      <code>$name</code>
+      <code>$name</code>
+      <code>$relations</code>
+      <code>$resource</code>
+      <code>$resource</code>
+      <code>$this-&gt;embedded[$name]</code>
+      <code>$value</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$name</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess occurrences="2">
+      <code>$byRelation[$rel]</code>
+      <code>$relations[$key]</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="6">
+      <code>$byRelation[$rel]</code>
+      <code>$byRelation[$rel]</code>
+      <code>$byRelation[$rel]</code>
+      <code>$embedded[$name]</code>
+      <code>$relations[$key]</code>
+      <code>$resource</code>
+    </MixedArrayAssignment>
+    <MixedArrayOffset occurrences="8">
+      <code>$byRelation[$rel]</code>
+      <code>$byRelation[$rel]</code>
+      <code>$byRelation[$rel]</code>
+      <code>$byRelation[$rel]</code>
+      <code>$embedded[$name]</code>
+      <code>$relations[$key]</code>
+      <code>$relations[$key]</code>
+      <code>$relations[$key]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="5">
+      <code>$collection</code>
+      <code>$relations</code>
+      <code>$relations[$key]</code>
+      <code>$resource</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="2">
+      <code>?HalResource</code>
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="1">
+      <code>toArray</code>
+    </MixedMethodCall>
+    <MixedPropertyTypeCoercion occurrences="3">
+      <code>$this-&gt;embedded</code>
+      <code>$this-&gt;embedded</code>
+      <code>$this-&gt;embedded</code>
+    </MixedPropertyTypeCoercion>
+    <MixedReturnStatement occurrences="2">
+      <code>$embedded</code>
+      <code>$resource</code>
+    </MixedReturnStatement>
+    <MixedReturnTypeCoercion occurrences="3">
+      <code>$forceCollection ? [$resource] : $resource</code>
+      <code>$this-&gt;aggregateEmbeddedCollection($name, $resource, $context)</code>
+      <code>HalResource|HalResource[]</code>
+    </MixedReturnTypeCoercion>
+    <PossiblyNullArgument occurrences="4">
+      <code>$resource</code>
+      <code>$this-&gt;firstResource($collection)</code>
+      <code>$this-&gt;firstResource($original)</code>
+      <code>$this-&gt;firstResource($this-&gt;embedded[$name])</code>
+    </PossiblyNullArgument>
+    <RedundantConditionGivenDocblockType occurrences="3">
+      <code>$this-&gt;embedded[$name] instanceof self</code>
+      <code>$this-&gt;embedded[$name] instanceof self</code>
+      <code>gettype($resource)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/HalResponseFactory.php">
+    <MixedArgument occurrences="1">
+      <code>$matchedType-&gt;getValue()</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$response</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="2">
+      <code>ResponseInterface</code>
+      <code>ResponseInterface</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="3">
+      <code>getBody</code>
+      <code>withHeader</code>
+      <code>write</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="2">
+      <code>$response-&gt;withHeader('Content-Type', $mediaType)</code>
+      <code>$responseFactory()</code>
+    </MixedReturnStatement>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getValue</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/HalResponseFactoryFactory.php">
+    <MixedArgument occurrences="3">
+      <code>$container-&gt;get(ResponseInterface::class)</code>
+      <code>$jsonRenderer</code>
+      <code>$xmlRenderer</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$jsonRenderer</code>
+      <code>$xmlRenderer</code>
+    </MixedAssignment>
+    <UndefinedDocblockClass occurrences="1">
+      <code>RuntimeException</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/Link.php">
+    <DocblockTypeContradiction occurrences="5">
+      <code>! is_string($attribute)</code>
+      <code>! is_string($href)</code>
+      <code>! is_string($rel)</code>
+      <code>! is_string($rel)</code>
+      <code>is_object($rel)</code>
+    </DocblockTypeContradiction>
+    <MissingClosureParamType occurrences="4">
+      <code>$isInvalid</code>
+      <code>$isString</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MissingClosureParamType>
+    <MixedArgument occurrences="1">
+      <code>$rel</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$value</code>
+    </MixedAssignment>
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>is_string($relation) ? [$relation] : $relation</code>
+      <code>string|string[]</code>
+    </MixedReturnTypeCoercion>
+    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
+      <code>$this-&gt;validateRelation($relation)</code>
+    </PossiblyInvalidPropertyAssignmentValue>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(string) $href</code>
+    </RedundantCastGivenDocblockType>
+    <RedundantCondition occurrences="1">
+      <code>is_string($uri)</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>gettype($rel)</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeDoesNotContainType occurrences="1">
+      <code>(string) $uri</code>
+    </TypeDoesNotContainType>
+  </file>
+  <file src="src/LinkCollection.php">
+    <LessSpecificImplementedReturnType occurrences="2">
+      <code>HalResource</code>
+      <code>HalResource</code>
+    </LessSpecificImplementedReturnType>
+    <MismatchingDocblockReturnType occurrences="2">
+      <code>HalResource</code>
+      <code>HalResource</code>
+    </MismatchingDocblockReturnType>
+    <MissingParamType occurrences="1">
+      <code>$rel</code>
+    </MissingParamType>
+    <MixedInferredReturnType occurrences="2">
+      <code>HalResource</code>
+      <code>HalResource</code>
+    </MixedInferredReturnType>
+  </file>
+  <file src="src/LinkGenerator/MezzioUrlGeneratorFactory.php">
+    <MixedArgument occurrences="3">
+      <code>$container-&gt;get($this-&gt;urlHelperServiceName)</code>
+      <code>$data['urlHelperServiceName'] ?? UrlHelper::class</code>
+    </MixedArgument>
+  </file>
+  <file src="src/LinkGeneratorFactory.php">
+    <MixedArgument occurrences="2">
+      <code>$container-&gt;get($this-&gt;urlGeneratorServiceName)</code>
+      <code>$data['urlGeneratorServiceName'] ?? LinkGenerator\UrlGeneratorInterface::class</code>
+    </MixedArgument>
+  </file>
+  <file src="src/Metadata/AbstractMetadata.php">
+    <MissingConstructor occurrences="1">
+      <code>$class</code>
+    </MissingConstructor>
+  </file>
+  <file src="src/Metadata/Exception/InvalidConfigException.php">
+    <MixedAssignment occurrences="1">
+      <code>$className</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Metadata/MetadataMapFactory.php">
+    <InvalidStringClass occurrences="1">
+      <code>new $factoryClass()</code>
+    </InvalidStringClass>
+    <MixedArgument occurrences="3">
+      <code>$metadataFactories</code>
+      <code>$metadataFactories[$metadataClass]</code>
+      <code>$metadata['__class__']</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="2">
+      <code>$config['mezzio-hal']</code>
+      <code>$config[MetadataMap::class]</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="2">
+      <code>$config</code>
+      <code>$metadataFactories</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>AbstractMetadata</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;$method($metadata)</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/Metadata/RouteBasedCollectionMetadataFactory.php">
+    <InvalidStringClass occurrences="1"/>
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MoreSpecificReturnType occurrences="1">
+      <code>AbstractMetadata</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="src/Metadata/RouteBasedResourceMetadataFactory.php">
+    <InvalidStringClass occurrences="1"/>
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MoreSpecificReturnType occurrences="1">
+      <code>AbstractMetadata</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="src/Metadata/UrlBasedCollectionMetadataFactory.php">
+    <InvalidStringClass occurrences="1"/>
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MoreSpecificReturnType occurrences="1">
+      <code>AbstractMetadata</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="src/Metadata/UrlBasedResourceMetadataFactory.php">
+    <InvalidStringClass occurrences="1"/>
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MoreSpecificReturnType occurrences="1">
+      <code>AbstractMetadata</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="src/Renderer/XmlRenderer.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>$elements</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>DOMNode|false|list&lt;DOMNode|false|list&lt;DOMNode|array&lt;array-key, DOMNode&gt;&gt;&gt;</code>
+    </InvalidReturnType>
+    <MixedArgument occurrences="11">
+      <code>$attribute</code>
+      <code>$childData</code>
+      <code>$childDatum</code>
+      <code>$data</code>
+      <code>$linkData</code>
+      <code>$linkDatum</code>
+      <code>$rel</code>
+      <code>$rel</code>
+      <code>$resource['_links']['self']['href']</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="4">
+      <code>$key</code>
+      <code>$key</code>
+      <code>$rel</code>
+      <code>$rel</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess occurrences="1">
+      <code>$resource['_links']['self']['href']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="16">
+      <code>$attribute</code>
+      <code>$child</code>
+      <code>$childData</code>
+      <code>$childDatum</code>
+      <code>$data</code>
+      <code>$linkData</code>
+      <code>$linkDatum</code>
+      <code>$rel</code>
+      <code>$resource['_embedded']</code>
+      <code>$resource['_links']</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <NullArgument occurrences="1">
+      <code>$data</code>
+    </NullArgument>
+    <PossibleRawObjectIteration occurrences="1">
+      <code>$resource['_links']</code>
+    </PossibleRawObjectIteration>
+    <PossiblyFalseArgument occurrences="1">
+      <code>$element</code>
+    </PossiblyFalseArgument>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$child</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="src/ResourceGenerator.php">
+    <MixedMethodCall occurrences="1">
+      <code>new $strategy()</code>
+    </MixedMethodCall>
+    <TypeDoesNotContainType occurrences="1">
+      <code>is_object($instance)</code>
+    </TypeDoesNotContainType>
+  </file>
+  <file src="src/ResourceGenerator/ExtractCollectionTrait.php">
+    <MixedArgument occurrences="3">
+      <code>$item</code>
+      <code>$item</code>
+      <code>$metadata</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$links</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="4">
+      <code>$count</code>
+      <code>$count</code>
+      <code>$item</code>
+      <code>$item</code>
+    </MixedAssignment>
+    <MixedOperand occurrences="1">
+      <code>$count</code>
+    </MixedOperand>
+    <PossiblyNullOperand occurrences="2">
+      <code>$perPage</code>
+      <code>$perPage</code>
+    </PossiblyNullOperand>
+    <TraitMethodSignatureMismatch occurrences="1"/>
+    <TypeDoesNotContainType occurrences="1">
+      <code>$metadata instanceof AbstractCollectionMetadata</code>
+    </TypeDoesNotContainType>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>count</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/ResourceGenerator/ExtractInstanceTrait.php">
+    <InvalidThrow occurrences="1">
+      <code>ContainerExceptionInterface</code>
+    </InvalidThrow>
+    <MixedArgument occurrences="1">
+      <code>$metadata-&gt;getExtractor()</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$array[$key]</code>
+      <code>$childData</code>
+    </MixedAssignment>
+    <UndefinedMethod occurrences="1">
+      <code>getExtractor</code>
+    </UndefinedMethod>
+  </file>
+  <file src="src/ResourceGenerator/RouteBasedCollectionStrategy.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>[]</code>
+    </DocblockTypeContradiction>
+    <MixedArgument occurrences="8">
+      <code>$metadata-&gt;getQueryStringArguments() ?? []</code>
+      <code>$metadata-&gt;getRoute()</code>
+      <code>$queryParams</code>
+      <code>$queryStringArgs</code>
+      <code>$route</code>
+      <code>$routeParams</code>
+      <code>$routeParams</code>
+      <code>$routeParams</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="6">
+      <code>$queryParams</code>
+      <code>$queryStringArgs</code>
+      <code>$route</code>
+      <code>$routeParams</code>
+      <code>$routeParams</code>
+      <code>$routeParams</code>
+    </MixedAssignment>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$request-&gt;getQueryParams()</code>
+    </RedundantConditionGivenDocblockType>
+    <TraitMethodSignatureMismatch occurrences="2">
+      <code>$resourceGenerator</code>
+      <code>protected function generateSelfLink(</code>
+    </TraitMethodSignatureMismatch>
+    <UndefinedMethod occurrences="6">
+      <code>getQueryStringArguments</code>
+      <code>getQueryStringArguments</code>
+      <code>getRoute</code>
+      <code>getRoute</code>
+      <code>getRouteParams</code>
+      <code>getRouteParams</code>
+    </UndefinedMethod>
+  </file>
+  <file src="src/ResourceGenerator/RouteBasedResourceStrategy.php">
+    <MixedArrayOffset occurrences="1">
+      <code>$routeParams[$placeholderMap[$key]]</code>
+    </MixedArrayOffset>
+  </file>
+  <file src="src/ResourceGenerator/UrlBasedCollectionStrategy.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>$page</code>
+    </InvalidScalarArgument>
+    <MixedArgument occurrences="1">
+      <code>$url</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$url</code>
+    </MixedAssignment>
+    <MixedOperand occurrences="1">
+      <code>$url</code>
+    </MixedOperand>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$queryStringArgs !== null</code>
+    </RedundantConditionGivenDocblockType>
+    <TraitMethodSignatureMismatch occurrences="2">
+      <code>$resourceGenerator</code>
+      <code>protected function generateSelfLink(</code>
+    </TraitMethodSignatureMismatch>
+    <UndefinedMethod occurrences="2">
+      <code>getUrl</code>
+      <code>getUrl</code>
+    </UndefinedMethod>
+  </file>
+  <file src="src/ResourceGeneratorFactory.php">
+    <MissingDependency occurrences="1">
+      <code>HydratorPluginManager</code>
+    </MissingDependency>
+    <MixedArgument occurrences="8">
+      <code>$container-&gt;get($strategy)</code>
+      <code>$container-&gt;get($this-&gt;linkGeneratorServiceName)</code>
+      <code>$container-&gt;get(HydratorPluginManager::class)</code>
+      <code>$container-&gt;get(Metadata\MetadataMap::class)</code>
+      <code>$data['linkGeneratorServiceName'] ?? LinkGenerator::class</code>
+      <code>$metadataType</code>
+      <code>$strategy</code>
+      <code>HydratorPluginManager::class</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$config['mezzio-hal']['resource-generator']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="2">
+      <code>$metadataType</code>
+      <code>$strategy</code>
+    </MixedAssignment>
+  </file>
+  <file src="test/Assertions.php">
+    <DeprecatedClass occurrences="1">
+      <code>ObjectProperty::class</code>
+    </DeprecatedClass>
+    <MixedArgument occurrences="2">
+      <code>$actual-&gt;getHref()</code>
+      <code>$actual-&gt;getRels()</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="4">
+      <code>getHref</code>
+      <code>getHref</code>
+      <code>getRels</code>
+      <code>getRels</code>
+    </MixedMethodCall>
+    <MoreSpecificReturnType occurrences="1">
+      <code>Link</code>
+    </MoreSpecificReturnType>
+    <RedundantCondition occurrences="1">
+      <code>assertIsArray</code>
+    </RedundantCondition>
+  </file>
+  <file src="test/ConfigProviderTest.php">
+    <RedundantCondition occurrences="1">
+      <code>assertIsArray</code>
+    </RedundantCondition>
+  </file>
+  <file src="test/ExceptionTest.php">
+    <InvalidLiteralArgument occurrences="1">
+      <code>ExceptionInterface::class</code>
+    </InvalidLiteralArgument>
+    <MixedInferredReturnType occurrences="1">
+      <code>Generator</code>
+    </MixedInferredReturnType>
+    <PossiblyFalseOperand occurrences="1">
+      <code>strrpos(ExceptionInterface::class, '\\')</code>
+    </PossiblyFalseOperand>
+  </file>
+  <file src="test/HalResourceTest.php">
+    <InvalidArgument occurrences="4">
+      <code>$links</code>
+      <code>[$name =&gt; $embedded]</code>
+      <code>['foo' =&gt; $embedded]</code>
+      <code>['foo' =&gt; 'bar']</code>
+    </InvalidArgument>
+    <MixedArgument occurrences="4">
+      <code>$representation['_embedded']</code>
+      <code>$representation['_embedded']</code>
+      <code>$representation['_embedded']</code>
+      <code>$representation['_embedded']</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="4">
+      <code>$representation['_embedded']['foo']</code>
+      <code>$representation['_embedded']['foo']</code>
+      <code>$representation['_embedded']['foo']</code>
+      <code>$representation['_embedded']['foo']</code>
+    </MixedArrayAccess>
+  </file>
+  <file src="test/HalResponseFactoryFactoryTest.php">
+    <DeprecatedMethod occurrences="6">
+      <code>self::assertAttributeInstanceOf(Renderer\JsonRenderer::class, 'jsonRenderer', $instance)</code>
+      <code>self::assertAttributeInstanceOf(Renderer\XmlRenderer::class, 'xmlRenderer', $instance)</code>
+      <code>self::assertAttributeSame($jsonRenderer, 'jsonRenderer', $instance)</code>
+      <code>self::assertAttributeSame($jsonRenderer, 'jsonRenderer', $instance)</code>
+      <code>self::assertAttributeSame($xmlRenderer, 'xmlRenderer', $instance)</code>
+      <code>self::assertAttributeSame($xmlRenderer, 'xmlRenderer', $instance)</code>
+    </DeprecatedMethod>
+    <MixedAssignment occurrences="1">
+      <code>$responseFactory</code>
+    </MixedAssignment>
+    <MixedFunctionCall occurrences="1">
+      <code>$responseFactory()</code>
+    </MixedFunctionCall>
+    <UndefinedClass occurrences="2">
+      <code>StreamInterface</code>
+      <code>StreamInterface</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/HalResponseFactoryTest.php">
+    <MixedAssignment occurrences="4">
+      <code>$response</code>
+      <code>$response</code>
+      <code>$response</code>
+      <code>$response</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="56">
+      <code>createResponse</code>
+      <code>createResponse</code>
+      <code>createResponse</code>
+      <code>createResponse</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getHeaderLine</code>
+      <code>getHeaderLine</code>
+      <code>getHeaderLine</code>
+      <code>getHeaderLine</code>
+      <code>render</code>
+      <code>render</code>
+      <code>render</code>
+      <code>render</code>
+      <code>render</code>
+      <code>render</code>
+      <code>render</code>
+      <code>render</code>
+      <code>render</code>
+      <code>render</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>withHeader</code>
+      <code>withHeader</code>
+      <code>withHeader</code>
+      <code>withHeader</code>
+    </MixedMethodCall>
+    <UndefinedThisPropertyAssignment occurrences="5">
+      <code>$this-&gt;factory</code>
+      <code>$this-&gt;jsonRenderer</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;response</code>
+      <code>$this-&gt;xmlRenderer</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="22">
+      <code>$this-&gt;factory</code>
+      <code>$this-&gt;factory</code>
+      <code>$this-&gt;factory</code>
+      <code>$this-&gt;factory</code>
+      <code>$this-&gt;jsonRenderer</code>
+      <code>$this-&gt;jsonRenderer</code>
+      <code>$this-&gt;jsonRenderer</code>
+      <code>$this-&gt;jsonRenderer</code>
+      <code>$this-&gt;jsonRenderer</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;response</code>
+      <code>$this-&gt;response</code>
+      <code>$this-&gt;response</code>
+      <code>$this-&gt;response</code>
+      <code>$this-&gt;xmlRenderer</code>
+      <code>$this-&gt;xmlRenderer</code>
+      <code>$this-&gt;xmlRenderer</code>
+      <code>$this-&gt;xmlRenderer</code>
+      <code>$this-&gt;xmlRenderer</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/LinkGenerator/MezzioUrlGeneratorFactoryTest.php">
+    <DeprecatedMethod occurrences="6">
+      <code>assertAttributeEmpty</code>
+      <code>assertAttributeSame</code>
+      <code>assertAttributeSame</code>
+      <code>assertAttributeSame</code>
+      <code>assertAttributeSame</code>
+      <code>assertAttributeSame</code>
+    </DeprecatedMethod>
+    <MixedArgument occurrences="5">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>CustomUrlHelper::class</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="44">
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="5">
+      <code>CustomUrlHelper</code>
+      <code>CustomUrlHelper</code>
+      <code>CustomUrlHelper</code>
+      <code>CustomUrlHelper</code>
+      <code>CustomUrlHelper</code>
+    </UndefinedClass>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;container</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="4">
+      <code>$this-&gt;container</code>
+      <code>$this-&gt;container</code>
+      <code>$this-&gt;container</code>
+      <code>$this-&gt;container</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/LinkGenerator/MezzioUrlGeneratorTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>assertAttributeEmpty</code>
+    </DeprecatedMethod>
+    <MissingClosureParamType occurrences="1">
+      <code>$fragment</code>
+    </MissingClosureParamType>
+  </file>
+  <file src="test/LinkGeneratorFactoryTest.php">
+    <DeprecatedMethod occurrences="3">
+      <code>assertAttributeSame</code>
+      <code>self::assertAttributeSame($urlGenerator, 'urlGenerator', $instance)</code>
+      <code>self::assertAttributeSame($urlGenerator, 'urlGenerator', $instance)</code>
+    </DeprecatedMethod>
+    <MixedArgument occurrences="1">
+      <code>UrlGenerator::class</code>
+    </MixedArgument>
+    <UndefinedClass occurrences="4">
+      <code>UrlGenerator</code>
+      <code>UrlGenerator</code>
+      <code>UrlGenerator</code>
+      <code>UrlGenerator</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/LinkTest.php">
+    <MixedArgument occurrences="7">
+      <code>$name</code>
+      <code>$name</code>
+      <code>$rel</code>
+      <code>$rel</code>
+      <code>$uri</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedArgument>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$uri</code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidCast occurrences="2">
+      <code>$uri</code>
+      <code>$uri</code>
+    </PossiblyInvalidCast>
+    <TooFewArguments occurrences="1">
+      <code>new Link()</code>
+    </TooFewArguments>
+  </file>
+  <file src="test/Metadata/ExceptionTest.php">
+    <InvalidLiteralArgument occurrences="1">
+      <code>ExceptionInterface::class</code>
+    </InvalidLiteralArgument>
+    <MixedInferredReturnType occurrences="1">
+      <code>Generator</code>
+    </MixedInferredReturnType>
+    <PossiblyFalseOperand occurrences="1">
+      <code>strrpos(ExceptionInterface::class, '\\')</code>
+    </PossiblyFalseOperand>
+  </file>
+  <file src="test/Metadata/MetadataMapFactoryTest.php">
+    <DeprecatedMethod occurrences="2">
+      <code>assertAttributeSame</code>
+      <code>assertAttributeSame</code>
+    </DeprecatedMethod>
+    <MixedArgument occurrences="15">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedInferredReturnType occurrences="1">
+      <code>Generator</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="14">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="15">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="15">
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="test/Metadata/MetadataMapTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$class</code>
+    </ArgumentTypeCoercion>
+    <InvalidArgument occurrences="1">
+      <code>testCanAggregateAnyMetadataType</code>
+    </InvalidArgument>
+    <MixedMethodCall occurrences="9">
+      <code>add</code>
+      <code>add</code>
+      <code>add</code>
+      <code>add</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>has</code>
+      <code>has</code>
+    </MixedMethodCall>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;map</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="4">
+      <code>$this-&gt;map</code>
+      <code>$this-&gt;map</code>
+      <code>$this-&gt;map</code>
+      <code>$this-&gt;map</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/PHPUnitDeprecatedAssertions.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$expected</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedMethod occurrences="5">
+      <code>static::readAttribute($actualClassOrObject, $actualAttributeName)</code>
+      <code>static::readAttribute($classOrObject, $attributeName)</code>
+      <code>static::readAttribute($haystackClassOrObject, $haystackAttributeName)</code>
+    </DeprecatedMethod>
+    <DocblockTypeContradiction occurrences="1">
+      <code>is_object($object)</code>
+    </DocblockTypeContradiction>
+    <InternalClass occurrences="3"/>
+    <MixedArgument occurrences="2">
+      <code>$stack[1]['class']</code>
+      <code>$stack[1]['function']</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$value</code>
+    </MixedAssignment>
+    <MixedOperand occurrences="1">
+      <code>$value</code>
+    </MixedOperand>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_object($classOrObject)</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeDoesNotContainType occurrences="1">
+      <code>! $attribute</code>
+    </TypeDoesNotContainType>
+  </file>
+  <file src="test/ResourceGenerator/DoctrinePaginatorTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>setMethods</code>
+    </DeprecatedMethod>
+    <InvalidReturnStatement occurrences="1"/>
+    <InvalidReturnType occurrences="1">
+      <code>MockObject&amp;MockedType</code>
+    </InvalidReturnType>
+    <MixedInferredReturnType occurrences="1">
+      <code>iterable</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="117">
+      <code>count</code>
+      <code>count</code>
+      <code>count</code>
+      <code>count</code>
+      <code>createResource</code>
+      <code>createResource</code>
+      <code>createResource</code>
+      <code>createResource</code>
+      <code>fromObject</code>
+      <code>fromObject</code>
+      <code>fromObject</code>
+      <code>fromRoute</code>
+      <code>getAttribute</code>
+      <code>getAttribute</code>
+      <code>getAttribute</code>
+      <code>getCollectionRelation</code>
+      <code>getCollectionRelation</code>
+      <code>getCollectionRelation</code>
+      <code>getIterator</code>
+      <code>getIterator</code>
+      <code>getIterator</code>
+      <code>getLinkGenerator</code>
+      <code>getLinkGenerator</code>
+      <code>getLinkGenerator</code>
+      <code>getPaginationParam</code>
+      <code>getPaginationParam</code>
+      <code>getPaginationParam</code>
+      <code>getPaginationParam</code>
+      <code>getPaginationParamType</code>
+      <code>getPaginationParamType</code>
+      <code>getPaginationParamType</code>
+      <code>getPaginationParamType</code>
+      <code>getQuery</code>
+      <code>getQuery</code>
+      <code>getQuery</code>
+      <code>getQuery</code>
+      <code>getQueryParams</code>
+      <code>getQueryParams</code>
+      <code>getQueryParams</code>
+      <code>getQueryParams</code>
+      <code>getQueryStringArguments</code>
+      <code>getQueryStringArguments</code>
+      <code>getQueryStringArguments</code>
+      <code>getRoute</code>
+      <code>getRoute</code>
+      <code>getRoute</code>
+      <code>getRouteParams</code>
+      <code>getRouteParams</code>
+      <code>getRouteParams</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <UndefinedDocblockClass occurrences="7">
+      <code>$query</code>
+      <code>$query</code>
+      <code>$query</code>
+      <code>$query</code>
+      <code>$query</code>
+      <code>$query</code>
+      <code>MockObject&amp;MockedType</code>
+    </UndefinedDocblockClass>
+    <UndefinedThisPropertyAssignment occurrences="6">
+      <code>$this-&gt;generator</code>
+      <code>$this-&gt;linkGenerator</code>
+      <code>$this-&gt;metadata</code>
+      <code>$this-&gt;paginator</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;strategy</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="25">
+      <code>$this-&gt;generator</code>
+      <code>$this-&gt;generator</code>
+      <code>$this-&gt;generator</code>
+      <code>$this-&gt;generator</code>
+      <code>$this-&gt;linkGenerator</code>
+      <code>$this-&gt;linkGenerator</code>
+      <code>$this-&gt;linkGenerator</code>
+      <code>$this-&gt;linkGenerator</code>
+      <code>$this-&gt;metadata</code>
+      <code>$this-&gt;metadata</code>
+      <code>$this-&gt;metadata</code>
+      <code>$this-&gt;metadata</code>
+      <code>$this-&gt;paginator</code>
+      <code>$this-&gt;paginator</code>
+      <code>$this-&gt;paginator</code>
+      <code>$this-&gt;paginator</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;strategy</code>
+      <code>$this-&gt;strategy</code>
+      <code>$this-&gt;strategy</code>
+      <code>$this-&gt;strategy</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/ResourceGenerator/ExceptionTest.php">
+    <InvalidLiteralArgument occurrences="1">
+      <code>ExceptionInterface::class</code>
+    </InvalidLiteralArgument>
+    <MixedInferredReturnType occurrences="1">
+      <code>Generator</code>
+    </MixedInferredReturnType>
+    <PossiblyFalseOperand occurrences="1">
+      <code>strrpos(ExceptionInterface::class, '\\')</code>
+    </PossiblyFalseOperand>
+  </file>
+  <file src="test/ResourceGenerator/NestedCollectionResourceGenerationTest.php">
+    <DeprecatedMethod occurrences="2">
+      <code>assertInternalType</code>
+      <code>assertInternalType</code>
+    </DeprecatedMethod>
+    <InvalidArgument occurrences="1">
+      <code>$request</code>
+    </InvalidArgument>
+    <InvalidStringClass occurrences="1">
+      <code>new $hydratorClass()</code>
+    </InvalidStringClass>
+    <MixedAssignment occurrences="1">
+      <code>$childCollection</code>
+    </MixedAssignment>
+    <UndefinedPropertyAssignment occurrences="1">
+      <code>$foo-&gt;children</code>
+    </UndefinedPropertyAssignment>
+  </file>
+  <file src="test/ResourceGenerator/ResourceWithNestedInstancesTest.php">
+    <InvalidArgument occurrences="1">
+      <code>$request</code>
+    </InvalidArgument>
+    <InvalidStringClass occurrences="1">
+      <code>new $hydratorClass()</code>
+    </InvalidStringClass>
+  </file>
+  <file src="test/ResourceGenerator/ResourceWithSelfReferringInstanceTest.php">
+    <InvalidStringClass occurrences="1">
+      <code>new $hydratorClass()</code>
+    </InvalidStringClass>
+    <MixedArgument occurrences="3">
+      <code>$hydrators-&gt;reveal()</code>
+      <code>$linkGenerator-&gt;reveal()</code>
+      <code>$metadataMap-&gt;reveal()</code>
+    </MixedArgument>
+    <PossiblyUndefinedMethod occurrences="3">
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="test/ResourceGenerator/RouteBasedCollectionWithRouteParamsTest.php">
+    <InvalidArgument occurrences="16">
+      <code>$linkGenerator</code>
+      <code>$linkGenerator</code>
+      <code>$linkGenerator</code>
+      <code>$linkGenerator</code>
+      <code>$linkGenerator</code>
+      <code>$linkGenerator</code>
+      <code>$linkGenerator</code>
+      <code>$request</code>
+      <code>$request</code>
+      <code>$request</code>
+      <code>$request</code>
+      <code>$request</code>
+      <code>$request</code>
+      <code>$request</code>
+    </InvalidArgument>
+    <InvalidStringClass occurrences="2">
+      <code>new $hydratorClass()</code>
+      <code>new $hydratorClass()</code>
+    </InvalidStringClass>
+    <MixedArgument occurrences="2">
+      <code>$request-&gt;reveal()</code>
+      <code>$request-&gt;reveal()</code>
+    </MixedArgument>
+  </file>
+  <file src="test/ResourceGenerator/UrlBasedCollectionWithRouteParamsTest.php">
+    <InvalidArgument occurrences="3">
+      <code>$linkGenerator</code>
+      <code>$request</code>
+    </InvalidArgument>
+    <InvalidStringClass occurrences="2">
+      <code>new $hydratorClass()</code>
+      <code>new $hydratorClass()</code>
+    </InvalidStringClass>
+    <MixedArgument occurrences="1">
+      <code>$request-&gt;reveal()</code>
+    </MixedArgument>
+  </file>
+  <file src="test/ResourceGeneratorFactoryTest.php">
+    <DeprecatedMethod occurrences="2">
+      <code>assertAttributeSame</code>
+      <code>assertAttributeSame</code>
+    </DeprecatedMethod>
+    <MissingDependency occurrences="2">
+      <code>HydratorPluginManager</code>
+      <code>HydratorPluginManager</code>
+    </MissingDependency>
+    <MixedArgument occurrences="5">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>CustomLinkGenerator::class</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="5">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="4">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="4">
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedClass occurrences="4">
+      <code>CustomLinkGenerator</code>
+      <code>CustomLinkGenerator</code>
+      <code>CustomLinkGenerator</code>
+      <code>CustomLinkGenerator</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/ResourceGeneratorTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>assertInternalType</code>
+    </DeprecatedMethod>
+    <InvalidArgument occurrences="13">
+      <code>Argument::type('array')</code>
+      <code>Argument::type('array')</code>
+      <code>Argument::type('array')</code>
+      <code>Argument::type('array')</code>
+      <code>Argument::type('array')</code>
+      <code>Argument::type('array')</code>
+      <code>Argument::type('array')</code>
+      <code>Argument::type('array')</code>
+      <code>Argument::type('array')</code>
+      <code>Argument::type('array')</code>
+    </InvalidArgument>
+    <InvalidStringClass occurrences="8">
+      <code>new $hydratorClass()</code>
+      <code>new $hydratorClass()</code>
+      <code>new $hydratorClass()</code>
+      <code>new $hydratorClass()</code>
+      <code>new $hydratorClass()</code>
+      <code>new $hydratorClass()</code>
+      <code>new $hydratorClass()</code>
+    </InvalidStringClass>
+    <MixedArgument occurrences="33">
+      <code>$embedded</code>
+      <code>$item</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="3">
+      <code>$embedded</code>
+      <code>$ids[]</code>
+      <code>$item</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="2">
+      <code>Generator</code>
+      <code>Generator</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="7">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="24">
+      <code>shouldNotBeCalled</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="76">
+      <code>getElement</code>
+      <code>getElement</code>
+      <code>getElement</code>
+      <code>getElement</code>
+      <code>getElement</code>
+      <code>getElement</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </PossiblyUndefinedMethod>
+    <TooFewArguments occurrences="4">
+      <code>fromRoute</code>
+      <code>fromRoute</code>
+      <code>fromRoute</code>
+      <code>has</code>
+    </TooFewArguments>
+  </file>
+  <file src="test/TestAsset/Child.php">
+    <MissingPropertyType occurrences="2">
+      <code>$id</code>
+      <code>$message</code>
+    </MissingPropertyType>
+  </file>
+  <file src="test/TestAsset/FooBar.php">
+    <MissingPropertyType occurrences="3">
+      <code>$bar</code>
+      <code>$foo</code>
+      <code>$id</code>
+    </MissingPropertyType>
+  </file>
+  <file src="test/TestAsset/Uri.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$uri</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnStatement occurrences="1">
+      <code>$this-&gt;uri</code>
+    </InvalidReturnStatement>
+    <InvalidToString occurrences="1">
+      <code>string</code>
+    </InvalidToString>
+    <UndefinedDocblockClass occurrences="1">
+      <code>strign</code>
+    </UndefinedDocblockClass>
+  </file>
+</files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <directory name="test"/>
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
+            </errorLevel>
+        </InternalMethod>
+    </issueHandlers>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/src/HalResource.php
+++ b/src/HalResource.php
@@ -360,7 +360,7 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
      * Exists as array_shift is destructive, and we cannot necessarily know the
      * index of the first element.
      *
-     * @param null|HalResource[] $resources
+     * @param array $resources
      */
     private function firstResource(array $resources): ?HalResource
     {

--- a/src/Link.php
+++ b/src/Link.php
@@ -41,7 +41,6 @@ class Link implements EvolvableLinkInterface
 
     /**
      * @param string|string[] $relation One or more relations represented by this link.
-     * @param string|object $uri
      * @param array $attributes
      * @throws InvalidArgumentException If $relation is neither a string nor an array.
      * @throws InvalidArgumentException If an array $relation is provided, but one or

--- a/src/LinkCollection.php
+++ b/src/LinkCollection.php
@@ -24,16 +24,22 @@ trait LinkCollection
 
     /**
      * {@inheritDoc}
+     *
+     * @return LinkInterface[]
+     * @psalm-return array<array-key, LinkInterface>
      */
-    public function getLinks()
+    public function getLinks(): array
     {
         return $this->links;
     }
 
     /**
      * {@inheritDoc}
+     *
+     * @return LinkInterface[]
+     * @psalm-return array<array-key, LinkInterface>
      */
-    public function getLinksByRel($rel)
+    public function getLinksByRel($rel): array
     {
         return array_filter($this->links, function (LinkInterface $link) use ($rel) {
             $rels = $link->getRels();
@@ -43,8 +49,10 @@ trait LinkCollection
 
     /**
      * {@inheritDoc}
+     *
+     * @return HalResource
      */
-    public function withLink(LinkInterface $link)
+    public function withLink(LinkInterface $link): self
     {
         if (in_array($link, $this->links, true)) {
             return $this;
@@ -57,8 +65,10 @@ trait LinkCollection
 
     /**
      * {@inheritDoc}
+     *
+     * @return HalResource
      */
-    public function withoutLink(LinkInterface $link)
+    public function withoutLink(LinkInterface $link): self
     {
         if (! in_array($link, $this->links, true)) {
             return $this;

--- a/src/LinkCollection.php
+++ b/src/LinkCollection.php
@@ -49,8 +49,6 @@ trait LinkCollection
 
     /**
      * {@inheritDoc}
-     *
-     * @return HalResource
      */
     public function withLink(LinkInterface $link): self
     {
@@ -65,8 +63,6 @@ trait LinkCollection
 
     /**
      * {@inheritDoc}
-     *
-     * @return HalResource
      */
     public function withoutLink(LinkInterface $link): self
     {

--- a/src/Metadata/MetadataMapFactory.php
+++ b/src/Metadata/MetadataMapFactory.php
@@ -92,7 +92,7 @@ class MetadataMapFactory
      * @throws Exception\InvalidConfigException If no matching `create*()`
      *     method is found for the "__class__" entry.
      */
-    private function injectMetadata(MetadataMap $metadataMap, array $metadata, array $metadataFactories)
+    private function injectMetadata(MetadataMap $metadataMap, array $metadata, array $metadataFactories): void
     {
         if (! isset($metadata['__class__'])) {
             throw Exception\InvalidConfigException::dueToMissingMetadataClass();

--- a/src/Renderer/XmlRenderer.php
+++ b/src/Renderer/XmlRenderer.php
@@ -112,7 +112,8 @@ class XmlRenderer implements RendererInterface
 
     /**
      * @param mixed $data
-     * @return DOMNode|DOMNode[]
+     * @return ((DOMNode|DOMNode[])[]|DOMNode|false)[]|DOMNode|false
+     * @psalm-return DOMNode|false|list<DOMNode|false|list<DOMNode|array<array-key, DOMNode>>>
      */
     private function createResourceElement(DOMDocument $doc, string $name, $data)
     {

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -18,7 +18,7 @@ use function array_values;
 
 class HalResourceTest extends TestCase
 {
-    public function testCanConstructWithData()
+    public function testCanConstructWithData(): void
     {
         $resource = new HalResource(['foo' => 'bar']);
         $this->assertEquals(['foo' => 'bar'], $resource->getElements());
@@ -39,14 +39,14 @@ class HalResourceTest extends TestCase
     /**
      * @dataProvider invalidElementNames
      */
-    public function testInvalidDataNamesRaiseExceptionsDuringConstruction(string $name, string $expectedMessage)
+    public function testInvalidDataNamesRaiseExceptionsDuringConstruction(string $name, string $expectedMessage): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($expectedMessage);
         $resource = new HalResource([$name => 'bar']);
     }
 
-    public function testCanConstructWithDataContainingEmbeddedResources()
+    public function testCanConstructWithDataContainingEmbeddedResources(): void
     {
         $embedded = new HalResource(['foo' => 'bar']);
         $resource = new HalResource(['foo' => $embedded]);
@@ -57,7 +57,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $representation['_embedded']['foo']);
     }
 
-    public function testCanConstructWithLinks()
+    public function testCanConstructWithLinks(): void
     {
         $links    = [
             new Link('self', 'https://example.com/'),
@@ -67,7 +67,7 @@ class HalResourceTest extends TestCase
         $this->assertSame($links, $resource->getLinks());
     }
 
-    public function testNonLinkItemsRaiseExceptionDuringConstruction()
+    public function testNonLinkItemsRaiseExceptionDuringConstruction(): void
     {
         $links = [
             new Link('self', 'https://example.com/'),
@@ -78,7 +78,7 @@ class HalResourceTest extends TestCase
         $resource = new HalResource([], $links);
     }
 
-    public function testCanConstructWithEmbeddedResources()
+    public function testCanConstructWithEmbeddedResources(): void
     {
         $embedded = new HalResource(['foo' => 'bar']);
         $resource = new HalResource([], [], ['foo' => $embedded]);
@@ -89,14 +89,14 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $representation['_embedded']['foo']);
     }
 
-    public function testNonResourceOrCollectionItemsRaiseExceptionDuringConstruction()
+    public function testNonResourceOrCollectionItemsRaiseExceptionDuringConstruction(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid embedded resource');
         $resource = new HalResource([], [], ['foo' => 'bar']);
     }
 
-    public function testEmptyArrayAsDataWillNotBeEmbeddedDuringConstruction()
+    public function testEmptyArrayAsDataWillNotBeEmbeddedDuringConstruction(): void
     {
         $resource = new HalResource(['bar' => []]);
         $this->assertEquals(['bar' => []], $resource->getElements());
@@ -107,15 +107,17 @@ class HalResourceTest extends TestCase
     /**
      * @dataProvider invalidElementNames
      */
-    public function testInvalidResourceNamesRaiseExceptionsDuringConstruction(string $name, string $expectedMessage)
-    {
+    public function testInvalidResourceNamesRaiseExceptionsDuringConstruction(
+        string $name,
+        string $expectedMessage
+    ): void {
         $embedded = new HalResource(['foo' => 'bar']);
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($expectedMessage);
         $resource = new HalResource([], [], [$name => $embedded]);
     }
 
-    public function testWithLinkReturnsNewInstanceContainingNewLink()
+    public function testWithLinkReturnsNewInstanceContainingNewLink(): void
     {
         $link     = new Link('self');
         $resource = new HalResource();
@@ -125,7 +127,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals([$link], $new->getLinksByRel('self'));
     }
 
-    public function testWithLinkReturnsSameInstanceIfAlreadyContainsLinkInstance()
+    public function testWithLinkReturnsSameInstanceIfAlreadyContainsLinkInstance(): void
     {
         $link     = new Link('self');
         $resource = new HalResource([], [$link]);
@@ -133,7 +135,7 @@ class HalResourceTest extends TestCase
         $this->assertSame($resource, $new);
     }
 
-    public function testWithoutLinkReturnsNewInstanceRemovingLink()
+    public function testWithoutLinkReturnsNewInstanceRemovingLink(): void
     {
         $link     = new Link('self');
         $resource = new HalResource([], [$link]);
@@ -143,7 +145,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals([], $new->getLinksByRel('self'));
     }
 
-    public function testWithoutLinkReturnsSameInstanceIfLinkIsNotPresent()
+    public function testWithoutLinkReturnsSameInstanceIfLinkIsNotPresent(): void
     {
         $link     = new Link('self');
         $resource = new HalResource();
@@ -151,7 +153,7 @@ class HalResourceTest extends TestCase
         $this->assertSame($resource, $new);
     }
 
-    public function testGetLinksByRelReturnsAllLinksWithGivenRelationshipAsArray()
+    public function testGetLinksByRelReturnsAllLinksWithGivenRelationshipAsArray(): void
     {
         $link1    = new Link('self');
         $link2    = new Link('about');
@@ -171,7 +173,7 @@ class HalResourceTest extends TestCase
     /**
      * @dataProvider invalidElementNames
      */
-    public function testWithElementRaisesExceptionForInvalidName(string $name, string $expectedMessage)
+    public function testWithElementRaisesExceptionForInvalidName(string $name, string $expectedMessage): void
     {
         $resource = new HalResource();
         $this->expectException(InvalidArgumentException::class);
@@ -179,7 +181,7 @@ class HalResourceTest extends TestCase
         $resource->withElement($name, 'foo');
     }
 
-    public function testWithElementRaisesExceptionIfNameCollidesWithExistingResource()
+    public function testWithElementRaisesExceptionIfNameCollidesWithExistingResource(): void
     {
         $embedded = new HalResource(['foo' => 'bar']);
         $resource = new HalResource(['foo' => $embedded]);
@@ -188,7 +190,7 @@ class HalResourceTest extends TestCase
         $resource->withElement('foo', 'bar');
     }
 
-    public function testWithElementReturnsNewInstanceWithNewElement()
+    public function testWithElementReturnsNewInstanceWithNewElement(): void
     {
         $resource = new HalResource();
         $new      = $resource->withElement('foo', 'bar');
@@ -197,7 +199,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $new->getElements());
     }
 
-    public function testWithElementReturnsNewInstanceOverwritingExistingElementValue()
+    public function testWithElementReturnsNewInstanceOverwritingExistingElementValue(): void
     {
         $resource = new HalResource(['foo' => 'bar']);
         $new      = $resource->withElement('foo', 'baz');
@@ -206,7 +208,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => 'baz'], $new->getElements());
     }
 
-    public function testWithElementProxiesToEmbedIfResourceValueProvided()
+    public function testWithElementProxiesToEmbedIfResourceValueProvided(): void
     {
         $embedded = new HalResource(['foo' => 'bar']);
         $resource = new HalResource();
@@ -220,7 +222,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $representation['_embedded']['foo']);
     }
 
-    public function testWithElementProxiesToEmbedIfResourceCollectionValueProvided()
+    public function testWithElementProxiesToEmbedIfResourceCollectionValueProvided(): void
     {
         $resource1  = new HalResource(['foo' => 'bar']);
         $resource2  = new HalResource(['foo' => 'baz']);
@@ -234,7 +236,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => $collection], $new->getElements());
     }
 
-    public function testWithElementDoesNotProxyToEmbedIfAnEmptyArrayValueIsProvided()
+    public function testWithElementDoesNotProxyToEmbedIfAnEmptyArrayValueIsProvided(): void
     {
         $resource = new HalResource(['foo' => 'bar']);
         $new      = $resource->withElement('bar', []);
@@ -246,7 +248,7 @@ class HalResourceTest extends TestCase
     /**
      * @dataProvider invalidElementNames
      */
-    public function testEmbedRaisesExceptionForInvalidName(string $name, string $expectedMessage)
+    public function testEmbedRaisesExceptionForInvalidName(string $name, string $expectedMessage): void
     {
         $resource = new HalResource();
         $this->expectException(InvalidArgumentException::class);
@@ -254,7 +256,7 @@ class HalResourceTest extends TestCase
         $resource->embed($name, new HalResource());
     }
 
-    public function testEmbedRaisesExceptionIfNameCollidesWithExistingData()
+    public function testEmbedRaisesExceptionIfNameCollidesWithExistingData(): void
     {
         $resource = new HalResource(['foo' => 'bar']);
         $this->expectException(RuntimeException::class);
@@ -262,7 +264,7 @@ class HalResourceTest extends TestCase
         $resource->embed('foo', new HalResource());
     }
 
-    public function testEmbedReturnsNewInstanceWithEmbeddedResource()
+    public function testEmbedReturnsNewInstanceWithEmbeddedResource(): void
     {
         $embedded = new HalResource(['foo' => 'bar']);
         $resource = new HalResource();
@@ -272,7 +274,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => $embedded], $new->getElements());
     }
 
-    public function testEmbedReturnsNewInstanceWithEmbeddedCollection()
+    public function testEmbedReturnsNewInstanceWithEmbeddedCollection(): void
     {
         $resource1  = new HalResource(['foo' => 'bar']);
         $resource2  = new HalResource(['foo' => 'baz']);
@@ -286,7 +288,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => $collection], $new->getElements());
     }
 
-    public function testEmbedReturnsNewInstanceAppendingResourceToExistingResource()
+    public function testEmbedReturnsNewInstanceAppendingResourceToExistingResource(): void
     {
         $resource1 = new HalResource(['foo' => 'bar']);
         $resource2 = new HalResource(['foo' => 'baz']);
@@ -298,7 +300,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => [$resource1, $resource2]], $new->getElements());
     }
 
-    public function testEmbedReturnsNewInstanceAppendingResourceToExistingCollection()
+    public function testEmbedReturnsNewInstanceAppendingResourceToExistingCollection(): void
     {
         $resource1  = new HalResource(['foo' => 'bar']);
         $resource2  = new HalResource(['foo' => 'baz']);
@@ -312,7 +314,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => [$resource1, $resource2, $resource3]], $new->getElements());
     }
 
-    public function testEmbedReturnsNewInstanceAppendingCollectionToExistingCollection()
+    public function testEmbedReturnsNewInstanceAppendingCollectionToExistingCollection(): void
     {
         $resource1   = new HalResource(['foo' => 'bar']);
         $resource2   = new HalResource(['foo' => 'baz']);
@@ -328,7 +330,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => $collection1 + $collection2], $new->getElements());
     }
 
-    public function testEmbedRaisesExceptionIfNewResourceDoesNotMatchStructureOfExisting()
+    public function testEmbedRaisesExceptionIfNewResourceDoesNotMatchStructureOfExisting(): void
     {
         $resource1 = new HalResource(['foo' => 'bar']);
         $resource2 = new HalResource(['bar' => 'baz']);
@@ -339,7 +341,7 @@ class HalResourceTest extends TestCase
         $resource->embed('foo', $resource2);
     }
 
-    public function testEmbedRaisesExceptionIfNewResourceDoesNotMatchCollectionResourceStructure()
+    public function testEmbedRaisesExceptionIfNewResourceDoesNotMatchCollectionResourceStructure(): void
     {
         $resource1  = new HalResource(['foo' => 'bar']);
         $resource2  = new HalResource(['foo' => 'baz']);
@@ -352,7 +354,7 @@ class HalResourceTest extends TestCase
         $resource->embed('foo', $resource3);
     }
 
-    public function testEmbedRaisesExceptionIfResourcesInCollectionAreNotOfSameStructure()
+    public function testEmbedRaisesExceptionIfResourcesInCollectionAreNotOfSameStructure(): void
     {
         $resource1  = new HalResource(['foo' => 'bar']);
         $resource2  = new HalResource(['bar' => 'bat']);
@@ -364,7 +366,7 @@ class HalResourceTest extends TestCase
         $resource->embed('foo', $collection);
     }
 
-    public function testWithElementsAddsNewDataToNewResourceInstance()
+    public function testWithElementsAddsNewDataToNewResourceInstance(): void
     {
         $resource = new HalResource();
         $new      = $resource->withElements(['foo' => 'bar']);
@@ -373,7 +375,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $new->getElements());
     }
 
-    public function testWithElementsAddsNewEmbeddedResourcesToNewResourceInstance()
+    public function testWithElementsAddsNewEmbeddedResourcesToNewResourceInstance(): void
     {
         $embedded = new HalResource(['foo' => 'bar']);
         $resource = new HalResource();
@@ -387,7 +389,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $representation['_embedded']['foo']);
     }
 
-    public function testWithElementsOverwritesExistingDataInNewResourceInstance()
+    public function testWithElementsOverwritesExistingDataInNewResourceInstance(): void
     {
         $resource = new HalResource(['foo' => 'bar']);
         $new      = $resource->withElements(['foo' => 'baz']);
@@ -396,7 +398,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => 'baz'], $new->getElements());
     }
 
-    public function testWithElementsAppendsEmbeddedResourcesToExistingResourcesInNewResourceInstance()
+    public function testWithElementsAppendsEmbeddedResourcesToExistingResourcesInNewResourceInstance(): void
     {
         $resource1 = new HalResource(['foo' => 'bar']);
         $resource2 = new HalResource(['foo' => 'bar']);
@@ -408,7 +410,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => [$resource1, $resource2]], $new->getElements());
     }
 
-    public function testWithoutElementRemovesDataElementIfItIsPresent()
+    public function testWithoutElementRemovesDataElementIfItIsPresent(): void
     {
         $resource = new HalResource(['foo' => 'bar']);
         $new      = $resource->withoutElement('foo');
@@ -417,14 +419,14 @@ class HalResourceTest extends TestCase
         $this->assertEquals([], $new->getElements());
     }
 
-    public function testWithoutElementDoesNothingIfElementOrResourceNotPresent()
+    public function testWithoutElementDoesNothingIfElementOrResourceNotPresent(): void
     {
         $resource = new HalResource(['foo' => 'bar']);
         $new      = $resource->withoutElement('bar');
         $this->assertSame($resource, $new);
     }
 
-    public function testWithoutElementRemovesEmbeddedResourceIfItIsPresent()
+    public function testWithoutElementRemovesEmbeddedResourceIfItIsPresent(): void
     {
         $embedded = new HalResource();
         $resource = new HalResource(['foo' => $embedded]);
@@ -434,7 +436,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals([], $new->getElements());
     }
 
-    public function testWithoutElementRemovesEmbeddedCollectionIfPresent()
+    public function testWithoutElementRemovesEmbeddedCollectionIfPresent(): void
     {
         $resource1  = new HalResource();
         $resource2  = new HalResource();
@@ -450,7 +452,7 @@ class HalResourceTest extends TestCase
     /**
      * @dataProvider invalidElementNames
      */
-    public function testWithoutElementRaisesExceptionForInvalidElementName(string $name, string $expectedMessage)
+    public function testWithoutElementRaisesExceptionForInvalidElementName(string $name, string $expectedMessage): void
     {
         $resource = new HalResource();
         $this->expectException(InvalidArgumentException::class);
@@ -517,7 +519,7 @@ class HalResourceTest extends TestCase
     /**
      * @dataProvider populatedResources
      */
-    public function testToArrayReturnsHalDataStructure(HalResource $resource, array $expected)
+    public function testToArrayReturnsHalDataStructure(HalResource $resource, array $expected): void
     {
         $this->assertEquals($expected, $resource->toArray());
     }
@@ -525,12 +527,12 @@ class HalResourceTest extends TestCase
     /**
      * @dataProvider populatedResources
      */
-    public function testJsonSerializeReturnsHalDataStructure(HalResource $resource, array $expected)
+    public function testJsonSerializeReturnsHalDataStructure(HalResource $resource, array $expected): void
     {
         $this->assertEquals($expected, $resource->jsonSerialize());
     }
 
-    public function testAllowsForcingResourceToAggregateAsACollection()
+    public function testAllowsForcingResourceToAggregateAsACollection(): void
     {
         $resource = (new HalResource())
             ->withLink(new Link('self', '/api/foo'))
@@ -561,7 +563,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals($expected, $resource->toArray());
     }
 
-    public function testAllowsForcingLinkToAggregateAsACollection()
+    public function testAllowsForcingLinkToAggregateAsACollection(): void
     {
         $link     = new Link('foo', '/api/foo', false, [Link::AS_COLLECTION => true]);
         $resource = new HalResource(['id' => 'foo'], [$link]);

--- a/test/HalResponseFactoryFactoryTest.php
+++ b/test/HalResponseFactoryFactoryTest.php
@@ -41,7 +41,7 @@ class HalResponseFactoryFactoryTest extends TestCase
         $jsonRenderer    = $this->prophesize(Renderer\JsonRenderer::class)->reveal();
         $xmlRenderer     = $this->prophesize(Renderer\XmlRenderer::class)->reveal();
         $response        = $this->prophesize(ResponseInterface::class)->reveal();
-        $responseFactory = function () use ($response) {
+        $responseFactory = function () use ($response): ResponseInterface {
             return $response;
         };
 
@@ -62,7 +62,7 @@ class HalResponseFactoryFactoryTest extends TestCase
     public function testReturnsHalResponseFactoryInstanceWithoutConfiguredDependencies(): void
     {
         $response        = $this->prophesize(ResponseInterface::class)->reveal();
-        $responseFactory = function () use ($response) {
+        $responseFactory = function () use ($response): ResponseInterface {
             return $response;
         };
         $container       = $this->prophesize(ContainerInterface::class);
@@ -79,12 +79,12 @@ class HalResponseFactoryFactoryTest extends TestCase
         self::assertResponseFactoryReturns($response, $instance);
     }
 
-    public function testReturnsHalResponseFactoryInstanceWhenResponseInterfaceReturnsFactory()
+    public function testReturnsHalResponseFactoryInstanceWhenResponseInterfaceReturnsFactory(): void
     {
         $jsonRenderer    = $this->prophesize(Renderer\JsonRenderer::class)->reveal();
         $xmlRenderer     = $this->prophesize(Renderer\XmlRenderer::class)->reveal();
         $response        = $this->prophesize(ResponseInterface::class)->reveal();
-        $responseFactory = function () use ($response) {
+        $responseFactory = function () use ($response): ResponseInterface {
             return $response;
         };
         $stream          = new class ()

--- a/test/HalResponseFactoryTest.php
+++ b/test/HalResponseFactoryTest.php
@@ -39,7 +39,7 @@ class HalResponseFactoryTest extends TestCase
         );
     }
 
-    public function testReturnsJsonResponseIfNoAcceptHeaderPresent()
+    public function testReturnsJsonResponseIfNoAcceptHeaderPresent(): void
     {
         $resource = $this->createExampleResource();
         $this->jsonRenderer->render($resource)->willReturn('{}');
@@ -73,7 +73,7 @@ class HalResponseFactoryTest extends TestCase
     /**
      * @dataProvider jsonAcceptHeaders
      */
-    public function testReturnsJsonResponseIfAcceptHeaderMatchesJson(string $header)
+    public function testReturnsJsonResponseIfAcceptHeaderMatchesJson(string $header): void
     {
         $resource = $this->createExampleResource();
         $this->jsonRenderer->render($resource)->willReturn('{}');
@@ -108,7 +108,7 @@ class HalResponseFactoryTest extends TestCase
     /**
      * @dataProvider xmlAcceptHeaders
      */
-    public function testReturnsXmlResponseIfAcceptHeaderMatchesXml(string $header)
+    public function testReturnsXmlResponseIfAcceptHeaderMatchesXml(string $header): void
     {
         $resource = $this->createExampleResource();
         $this->xmlRenderer->render($resource)->willReturn('<resource/>');
@@ -148,7 +148,7 @@ class HalResponseFactoryTest extends TestCase
         string $mediaType,
         string $responseBody,
         string $expectedMediaType
-    ) {
+    ): void {
         $resource = $this->createExampleResource();
         switch (true) {
             case strstr($header, 'json'):

--- a/test/LinkGenerator/MezzioUrlGeneratorFactoryTest.php
+++ b/test/LinkGenerator/MezzioUrlGeneratorFactoryTest.php
@@ -29,7 +29,7 @@ class MezzioUrlGeneratorFactoryTest extends TestCase
         $this->container = $this->prophesize(ContainerInterface::class);
     }
 
-    public function testFactoryRaisesExceptionIfUrlHelperIsMissingFromContainer()
+    public function testFactoryRaisesExceptionIfUrlHelperIsMissingFromContainer(): void
     {
         $this->container->has(UrlHelper::class)->willReturn(false);
         $this->container->has(\Zend\Expressive\Helper\UrlHelper::class)->willReturn(false);
@@ -44,7 +44,7 @@ class MezzioUrlGeneratorFactoryTest extends TestCase
         $factory($this->container->reveal());
     }
 
-    public function testFactoryCanCreateUrlGeneratorWithOnlyUrlHelperPresentInContainer()
+    public function testFactoryCanCreateUrlGeneratorWithOnlyUrlHelperPresentInContainer(): void
     {
         $urlHelper = $this->prophesize(UrlHelper::class)->reveal();
 
@@ -62,7 +62,7 @@ class MezzioUrlGeneratorFactoryTest extends TestCase
         $this->assertAttributeSame($urlHelper, 'urlHelper', $generator);
     }
 
-    public function testFactoryCanCreateUrlGeneratorWithBothUrlHelperAndServerUrlHelper()
+    public function testFactoryCanCreateUrlGeneratorWithBothUrlHelperAndServerUrlHelper(): void
     {
         $urlHelper       = $this->prophesize(UrlHelper::class)->reveal();
         $serverUrlHelper = $this->prophesize(ServerUrlHelper::class)->reveal();
@@ -80,7 +80,7 @@ class MezzioUrlGeneratorFactoryTest extends TestCase
         $this->assertAttributeSame($serverUrlHelper, 'serverUrlHelper', $generator);
     }
 
-    public function testFactoryCanAcceptUrlHelperServiceNameToConstructor()
+    public function testFactoryCanAcceptUrlHelperServiceNameToConstructor(): void
     {
         $urlHelper = $this->prophesize(UrlHelper::class)->reveal();
 
@@ -97,7 +97,7 @@ class MezzioUrlGeneratorFactoryTest extends TestCase
         $this->assertAttributeEmpty('serverUrlHelper', $generator);
     }
 
-    public function testFactoryIsSerializable()
+    public function testFactoryIsSerializable(): void
     {
         $factory = MezzioUrlGeneratorFactory::__set_state([
             'urlHelperServiceName' => CustomUrlHelper::class,

--- a/test/LinkGenerator/MezzioUrlGeneratorTest.php
+++ b/test/LinkGenerator/MezzioUrlGeneratorTest.php
@@ -24,7 +24,7 @@ class MezzioUrlGeneratorTest extends TestCase
 
     use ProphecyTrait;
 
-    public function testCanGenerateUrlWithOnlyUrlHelper()
+    public function testCanGenerateUrlWithOnlyUrlHelper(): void
     {
         $urlHelper = $this->prophesize(UrlHelper::class);
         $urlHelper->generate('test', ['foo' => 'bar'], ['baz' => 'bat'])->willReturn('/test/bar?baz=bat');
@@ -42,7 +42,7 @@ class MezzioUrlGeneratorTest extends TestCase
         ));
     }
 
-    public function testCanGenerateFullyQualifiedURIWhenServerUrlHelperIsComposed()
+    public function testCanGenerateFullyQualifiedURIWhenServerUrlHelperIsComposed(): void
     {
         $uri = $this->prophesize(UriInterface::class);
         $uri->withQuery('')->will([$uri, 'reveal']);

--- a/test/LinkGeneratorFactoryTest.php
+++ b/test/LinkGeneratorFactoryTest.php
@@ -34,7 +34,7 @@ class LinkGeneratorFactoryTest extends TestCase
         self::assertAttributeSame($urlGenerator, 'urlGenerator', $instance);
     }
 
-    public function testConstructorAllowsSpecifyingUrlGeneratorServiceName()
+    public function testConstructorAllowsSpecifyingUrlGeneratorServiceName(): void
     {
         $urlGenerator = $this->prophesize(LinkGenerator\UrlGeneratorInterface::class)->reveal();
 
@@ -46,7 +46,7 @@ class LinkGeneratorFactoryTest extends TestCase
         self::assertAttributeSame($urlGenerator, 'urlGenerator', $instance);
     }
 
-    public function testFactoryIsSerializable()
+    public function testFactoryIsSerializable(): void
     {
         $factory = LinkGeneratorFactory::__set_state([
             'urlGeneratorServiceName' => UrlGenerator::class,

--- a/test/LinkGeneratorTest.php
+++ b/test/LinkGeneratorTest.php
@@ -18,7 +18,7 @@ class LinkGeneratorTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function testUsesComposedUrlGeneratorToGenerateHrefForLink()
+    public function testUsesComposedUrlGeneratorToGenerateHrefForLink(): void
     {
         $request = $this->prophesize(ServerRequestInterface::class)->reveal();
 
@@ -48,7 +48,7 @@ class LinkGeneratorTest extends TestCase
         $this->assertFalse($link->isTemplated());
     }
 
-    public function testUsesComposedUrlGeneratorToGenerateHrefForTemplatedLink()
+    public function testUsesComposedUrlGeneratorToGenerateHrefForTemplatedLink(): void
     {
         $request = $this->prophesize(ServerRequestInterface::class)->reveal();
 

--- a/test/LinkTest.php
+++ b/test/LinkTest.php
@@ -16,13 +16,13 @@ use Psr\Link\EvolvableLinkInterface;
 
 class LinkTest extends TestCase
 {
-    public function testRequiresRelation()
+    public function testRequiresRelation(): void
     {
         $this->expectException(ArgumentCountError::class);
         $link = new Link();
     }
 
-    public function testCanConstructLinkWithRelation()
+    public function testCanConstructLinkWithRelation(): void
     {
         $link = new Link('self');
         $this->assertInstanceOf(Link::class, $link);
@@ -33,28 +33,28 @@ class LinkTest extends TestCase
         $this->assertEquals([], $link->getAttributes());
     }
 
-    public function testCanConstructLinkWithRelationAndUri()
+    public function testCanConstructLinkWithRelationAndUri(): void
     {
         $link = new Link('self', 'https://example.com/api/link');
         $this->assertEquals(['self'], $link->getRels());
         $this->assertEquals('https://example.com/api/link', $link->getHref());
     }
 
-    public function testCanConstructLinkWithRelationAndTemplatedFlag()
+    public function testCanConstructLinkWithRelationAndTemplatedFlag(): void
     {
         $link = new Link('self', '', true);
         $this->assertEquals(['self'], $link->getRels());
         $this->assertTrue($link->isTemplated());
     }
 
-    public function testCanConstructLinkWithRelationAndAttributes()
+    public function testCanConstructLinkWithRelationAndAttributes(): void
     {
         $link = new Link('self', '', false, ['foo' => 'bar']);
         $this->assertEquals(['self'], $link->getRels());
         $this->assertEquals(['foo' => 'bar'], $link->getAttributes());
     }
 
-    public function testCanConstructFullyPopulatedLink()
+    public function testCanConstructFullyPopulatedLink(): void
     {
         $link = new Link(
             ['self', 'link'],
@@ -91,21 +91,21 @@ class LinkTest extends TestCase
      * @dataProvider invalidRelations
      * @param mixed $rel
      */
-    public function testWithRelRaisesExceptionForInvalidRelation($rel)
+    public function testWithRelRaisesExceptionForInvalidRelation($rel): void
     {
         $link = new Link('self');
         $this->expectException(InvalidArgumentException::class);
         $link->withRel($rel);
     }
 
-    public function testWithRelReturnsSameInstanceIfRelationIsAlreadyPresent()
+    public function testWithRelReturnsSameInstanceIfRelationIsAlreadyPresent(): void
     {
         $link = new Link('self');
         $new  = $link->withRel('self');
         $this->assertSame($link, $new);
     }
 
-    public function testWithRelReturnsNewInstanceIfRelationIsNotAlreadyPresent()
+    public function testWithRelReturnsNewInstanceIfRelationIsNotAlreadyPresent(): void
     {
         $link = new Link('self');
         $new  = $link->withRel('link');
@@ -118,21 +118,21 @@ class LinkTest extends TestCase
      * @dataProvider invalidRelations
      * @param mixed $rel
      */
-    public function testWithoutRelReturnsSameInstanceIfRelationIsInvalid($rel)
+    public function testWithoutRelReturnsSameInstanceIfRelationIsInvalid($rel): void
     {
         $link = new Link('self');
         $new  = $link->withoutRel($rel);
         $this->assertSame($link, $new);
     }
 
-    public function testWithoutRelReturnsSameInstanceIfRelationIsNotPresent()
+    public function testWithoutRelReturnsSameInstanceIfRelationIsNotPresent(): void
     {
         $link = new Link('self');
         $new  = $link->withoutRel('link');
         $this->assertSame($link, $new);
     }
 
-    public function testWithoutRelReturnsNewInstanceIfRelationCanBeRemoved()
+    public function testWithoutRelReturnsNewInstanceIfRelationCanBeRemoved(): void
     {
         $link = new Link(['self', 'link']);
         $new  = $link->withoutRel('link');
@@ -163,7 +163,7 @@ class LinkTest extends TestCase
      * @dataProvider invalidUriTypes
      * @param mixed $uri
      */
-    public function testWithHrefRaisesExceptionForInvalidUriType($uri)
+    public function testWithHrefRaisesExceptionForInvalidUriType($uri): void
     {
         $link = new Link('self');
         $this->expectException(InvalidArgumentException::class);
@@ -183,7 +183,7 @@ class LinkTest extends TestCase
      * @dataProvider validUriTypes
      * @param string|object $uri
      */
-    public function testWithHrefReturnsNewInstanceWhenUriIsValid($uri)
+    public function testWithHrefReturnsNewInstanceWhenUriIsValid($uri): void
     {
         $link = new Link('self', 'https://example.com');
         $new  = $link->withHref($uri);
@@ -215,7 +215,7 @@ class LinkTest extends TestCase
      * @dataProvider invalidAttributeNames
      * @param mixed $name
      */
-    public function testWithAttributeRaisesExceptionForInvalidAttributeName($name)
+    public function testWithAttributeRaisesExceptionForInvalidAttributeName($name): void
     {
         $link = new Link('self');
         $this->expectException(InvalidArgumentException::class);
@@ -238,7 +238,7 @@ class LinkTest extends TestCase
      * @dataProvider invalidAttributeValues
      * @param mixed $value
      */
-    public function testWithAttributeRaisesExceptionForInvalidAttributeValue($value)
+    public function testWithAttributeRaisesExceptionForInvalidAttributeValue($value): void
     {
         $link = new Link('self');
         $this->expectException(InvalidArgumentException::class);
@@ -267,7 +267,7 @@ class LinkTest extends TestCase
      * @dataProvider validAttributes
      * @param mixed $value
      */
-    public function testWithAttributeReturnsNewInstanceForValidAttribute(string $name, $value)
+    public function testWithAttributeReturnsNewInstanceForValidAttribute(string $name, $value): void
     {
         $link = new Link('self');
         $new  = $link->withAttribute($name, $value);
@@ -280,21 +280,21 @@ class LinkTest extends TestCase
      * @dataProvider invalidAttributeNames
      * @param mixed $name
      */
-    public function testWithoutAttributeReturnsSameInstanceWhenAttributeNameIsInvalid($name)
+    public function testWithoutAttributeReturnsSameInstanceWhenAttributeNameIsInvalid($name): void
     {
         $link = new Link('self');
         $new  = $link->withoutAttribute($name);
         $this->assertSame($link, $new);
     }
 
-    public function testWithoutAttributeReturnsSameInstanceWhenAttributeIsNotPresent()
+    public function testWithoutAttributeReturnsSameInstanceWhenAttributeIsNotPresent(): void
     {
         $link = new Link('self', '', false, ['foo' => 'bar']);
         $new  = $link->withoutAttribute('bar');
         $this->assertSame($link, $new);
     }
 
-    public function testWithoutAttributeReturnsNewInstanceWhenAttributeCanBeRemoved()
+    public function testWithoutAttributeReturnsNewInstanceWhenAttributeCanBeRemoved(): void
     {
         $link = new Link('self', '', false, ['foo' => 'bar']);
         $new  = $link->withoutAttribute('foo');

--- a/test/Metadata/MetadataMapFactoryTest.php
+++ b/test/Metadata/MetadataMapFactoryTest.php
@@ -47,7 +47,7 @@ class MetadataMapFactoryTest extends TestCase
         $this->factory   = new MetadataMapFactory();
     }
 
-    public function testFactoryReturnsEmptyMetadataMapWhenNoConfigServicePresent()
+    public function testFactoryReturnsEmptyMetadataMapWhenNoConfigServicePresent(): void
     {
         $this->container->has('config')->willReturn(false);
         $metadataMap = ($this->factory)($this->container->reveal());
@@ -55,7 +55,7 @@ class MetadataMapFactoryTest extends TestCase
         $this->assertAttributeSame([], 'map', $metadataMap);
     }
 
-    public function testFactoryReturnsEmptyMetadataMapWhenConfigServiceHasNoMetadataMapEntries()
+    public function testFactoryReturnsEmptyMetadataMapWhenConfigServiceHasNoMetadataMapEntries(): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([]);
@@ -64,7 +64,7 @@ class MetadataMapFactoryTest extends TestCase
         $this->assertAttributeSame([], 'map', $metadataMap);
     }
 
-    public function testFactoryRaisesExceptionIfMetadataMapConfigIsNotAnArray()
+    public function testFactoryRaisesExceptionIfMetadataMapConfigIsNotAnArray(): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([MetadataMap::class => 'nope']);
@@ -73,7 +73,7 @@ class MetadataMapFactoryTest extends TestCase
         ($this->factory)($this->container->reveal());
     }
 
-    public function testFactoryRaisesExceptionIfMetadataMapItemIsNotAnArray()
+    public function testFactoryRaisesExceptionIfMetadataMapItemIsNotAnArray(): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([MetadataMap::class => ['nope']]);
@@ -82,7 +82,7 @@ class MetadataMapFactoryTest extends TestCase
         ($this->factory)($this->container->reveal());
     }
 
-    public function testFactoryRaisesExceptionIfAnyMetadataIsMissingAClassEntry()
+    public function testFactoryRaisesExceptionIfAnyMetadataIsMissingAClassEntry(): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([MetadataMap::class => [['nope']]]);
@@ -91,7 +91,7 @@ class MetadataMapFactoryTest extends TestCase
         ($this->factory)($this->container->reveal());
     }
 
-    public function testFactoryRaisesExceptionIfTheMetadataClassDoesNotExist()
+    public function testFactoryRaisesExceptionIfTheMetadataClassDoesNotExist(): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([
@@ -106,7 +106,7 @@ class MetadataMapFactoryTest extends TestCase
         ($this->factory)($this->container->reveal());
     }
 
-    public function testFactoryRaisesExceptionIfTheMetadataClassIsNotAnAbstractMetadataType()
+    public function testFactoryRaisesExceptionIfTheMetadataClassIsNotAnAbstractMetadataType(): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([
@@ -121,7 +121,7 @@ class MetadataMapFactoryTest extends TestCase
         ($this->factory)($this->container->reveal());
     }
 
-    public function testFactoryRaisesExceptionIfMetadataClassDoesNotHaveACreationMethodInTheFactory()
+    public function testFactoryRaisesExceptionIfMetadataClassDoesNotHaveACreationMethodInTheFactory(): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([
@@ -136,7 +136,7 @@ class MetadataMapFactoryTest extends TestCase
         ($this->factory)($this->container->reveal());
     }
 
-    public function testFactoryRaisesExceptionIfMetadataFactoryDoesNotImplementFactoryInterface()
+    public function testFactoryRaisesExceptionIfMetadataFactoryDoesNotImplementFactoryInterface(): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn(
@@ -176,7 +176,7 @@ class MetadataMapFactoryTest extends TestCase
     public function testFactoryRaisesExceptionIfMetadataIsMissingRequiredElements(
         array $metadata,
         string $expectExceptionString
-    ) {
+    ): void {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn(
             [
@@ -196,7 +196,7 @@ class MetadataMapFactoryTest extends TestCase
         ($this->factory)($this->container->reveal());
     }
 
-    public function testFactoryCanMapUrlBasedResourceMetadata()
+    public function testFactoryCanMapUrlBasedResourceMetadata(): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn(
@@ -228,7 +228,7 @@ class MetadataMapFactoryTest extends TestCase
         $this->assertSame('/test/foo', $metadata->getUrl());
     }
 
-    public function testFactoryCanMapUrlBasedCollectionMetadata()
+    public function testFactoryCanMapUrlBasedCollectionMetadata(): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn(
@@ -264,7 +264,7 @@ class MetadataMapFactoryTest extends TestCase
         $this->assertSame(Metadata\AbstractCollectionMetadata::TYPE_PLACEHOLDER, $metadata->getPaginationParamType());
     }
 
-    public function testFactoryCanMapRouteBasedResourceMetadata()
+    public function testFactoryCanMapRouteBasedResourceMetadata(): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn(
@@ -308,7 +308,7 @@ class MetadataMapFactoryTest extends TestCase
         ], $metadata->getIdentifiersToPlaceholdersMapping());
     }
 
-    public function testFactoryCanMapRouteBasedCollectionMetadata()
+    public function testFactoryCanMapRouteBasedCollectionMetadata(): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn(
@@ -348,7 +348,7 @@ class MetadataMapFactoryTest extends TestCase
         $this->assertSame(['baz' => 'bat'], $metadata->getQueryStringArguments());
     }
 
-    public function testFactoryCanCreateMetadataViaFactoryMethod()
+    public function testFactoryCanCreateMetadataViaFactoryMethod(): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn(

--- a/test/Metadata/MetadataMapTest.php
+++ b/test/Metadata/MetadataMapTest.php
@@ -8,10 +8,10 @@
 
 namespace MezzioTest\Hal\Metadata;
 
+use Generator;
 use Mezzio\Hal\Metadata;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 
 class MetadataMapTest extends TestCase
 {
@@ -34,9 +34,9 @@ class MetadataMapTest extends TestCase
     }
 
     /**
-     * @psalm-return iterable<string, Metadata\AbstractMetadata&ObjectProphecy>
+     * @psalm-return Generator<string, array{0: string, 1: object}, mixed, void>
      */
-    public function validMetadataTypes(): iterable
+    public function validMetadataTypes(): Generator
     {
         foreach ($this->metadataClasses as $class) {
             $metadata = $this->prophesize($class);
@@ -48,7 +48,7 @@ class MetadataMapTest extends TestCase
     /**
      * @dataProvider validMetadataTypes
      */
-    public function testCanAggregateAnyMetadataType(string $class, Metadata\AbstractMetadata $metadata)
+    public function testCanAggregateAnyMetadataType(string $class, Metadata\AbstractMetadata $metadata): void
     {
         $this->assertFalse($this->map->has($class));
         $this->map->add($metadata);
@@ -56,7 +56,7 @@ class MetadataMapTest extends TestCase
         $this->assertSame($metadata, $this->map->get($class));
     }
 
-    public function testAddWillRaiseUndefinedClassExceptionIfClassDoesNotExist()
+    public function testAddWillRaiseUndefinedClassExceptionIfClassDoesNotExist(): void
     {
         $metadata = $this->prophesize(Metadata\AbstractMetadata::class);
         $metadata->getClass()->willReturn('undefined-class');
@@ -66,7 +66,7 @@ class MetadataMapTest extends TestCase
         $this->map->add($metadata->reveal());
     }
 
-    public function testAddWillRaiseDuplicateMetadataExceptionWhenDuplicateMetadataEncountered()
+    public function testAddWillRaiseDuplicateMetadataExceptionWhenDuplicateMetadataEncountered(): void
     {
         $first = $this->prophesize(Metadata\AbstractMetadata::class);
         $first->getClass()->willReturn(self::class);
@@ -82,7 +82,7 @@ class MetadataMapTest extends TestCase
         $this->map->add($second->reveal());
     }
 
-    public function testGetWilRaiseUndefinedMetadataExceptionIfClassNotPresentInMap()
+    public function testGetWilRaiseUndefinedMetadataExceptionIfClassNotPresentInMap(): void
     {
         $this->expectException(Metadata\Exception\UndefinedMetadataException::class);
         $this->expectExceptionMessage(self::class);

--- a/test/PHPUnitDeprecatedAssertions.php
+++ b/test/PHPUnitDeprecatedAssertions.php
@@ -240,7 +240,10 @@ trait PHPUnitDeprecatedAssertions
         );
     }
 
-    private static function isValidClassAttributeName(string $attributeName): bool
+    /**
+     * @return false|int
+     */
+    private static function isValidClassAttributeName(string $attributeName)
     {
         return preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName);
     }

--- a/test/Renderer/JsonRendererTest.php
+++ b/test/Renderer/JsonRendererTest.php
@@ -17,7 +17,7 @@ class JsonRendererTest extends TestCase
 {
     use TestAsset;
 
-    public function testDelegatesToJsonEncode()
+    public function testDelegatesToJsonEncode(): void
     {
         $renderer = new JsonRenderer();
         $resource = $this->createExampleResource();
@@ -26,7 +26,7 @@ class JsonRendererTest extends TestCase
         $this->assertEquals($expected, $renderer->render($resource));
     }
 
-    public function testRendersUsingJsonFlagsProvidedToConstructor()
+    public function testRendersUsingJsonFlagsProvidedToConstructor(): void
     {
         $jsonFlags = 0;
         $renderer  = new JsonRenderer($jsonFlags);

--- a/test/Renderer/XmlRendererTest.php
+++ b/test/Renderer/XmlRendererTest.php
@@ -58,7 +58,7 @@ class XmlRendererTest extends TestCase
         return $xml;
     }
 
-    public function testRendersExpectedXmlPayload()
+    public function testRendersExpectedXmlPayload(): void
     {
         $resource = $this->createExampleResource();
         $expected = $this->createExampleXmlPayload();
@@ -70,7 +70,7 @@ class XmlRendererTest extends TestCase
     /**
      * @see https://github.com/zendframework/zend-expressive-hal/issues/3
      */
-    public function testCanRenderPhpDateTimeInstances()
+    public function testCanRenderPhpDateTimeInstances(): void
     {
         $dateTime = new DateTime('now');
         $resource = new HalResource([
@@ -83,7 +83,7 @@ class XmlRendererTest extends TestCase
         $this->assertStringContainsString($dateTime->format('c'), $xml);
     }
 
-    public function testCanRenderObjectsThatImplementToString()
+    public function testCanRenderObjectsThatImplementToString(): void
     {
         $instance = new StringSerializable();
 
@@ -97,7 +97,7 @@ class XmlRendererTest extends TestCase
         $this->assertStringContainsString((string) $instance, $xml);
     }
 
-    public function testRendersNullValuesAsTagsWithNoContent()
+    public function testRendersNullValuesAsTagsWithNoContent(): void
     {
         $resource = new HalResource([
             'key' => null,

--- a/test/ResourceGenerator/DoctrinePaginatorTest.php
+++ b/test/ResourceGenerator/DoctrinePaginatorTest.php
@@ -18,6 +18,7 @@ use Mezzio\Hal\Metadata\RouteBasedCollectionMetadata;
 use Mezzio\Hal\ResourceGenerator;
 use Mezzio\Hal\ResourceGenerator\Exception\OutOfBoundsException;
 use Mezzio\Hal\ResourceGenerator\RouteBasedCollectionStrategy;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -41,7 +42,11 @@ class DoctrinePaginatorTest extends TestCase
         $this->strategy = new RouteBasedCollectionStrategy();
     }
 
-    public function mockQuery(): AbstractQuery
+    /**
+     * @return MockObject&mixed
+     * @psalm-return MockObject&MockedType
+     */
+    public function mockQuery()
     {
         return $this->getMockBuilder(AbstractQuery::class)
             ->disableOriginalConstructor()
@@ -49,8 +54,12 @@ class DoctrinePaginatorTest extends TestCase
             ->getMockForAbstractClass();
     }
 
-    public function mockLinkGeneration(string $relation, string $route, array $routeParams, array $queryStringArgs)
-    {
+    public function mockLinkGeneration(
+        string $relation,
+        string $route,
+        array $routeParams,
+        array $queryStringArgs
+    ): void {
         $link = $this->prophesize(Link::class)->reveal();
         $this->linkGenerator
             ->fromRoute(
@@ -73,7 +82,7 @@ class DoctrinePaginatorTest extends TestCase
     /**
      * @dataProvider invalidPageCombinations
      */
-    public function testThrowsOutOfBoundsExceptionForInvalidPage(int $page, int $numPages)
+    public function testThrowsOutOfBoundsExceptionForInvalidPage(int $page, int $numPages): void
     {
         $query = $this->mockQuery();
         $query->expects($this->once())
@@ -96,7 +105,7 @@ class DoctrinePaginatorTest extends TestCase
         );
     }
 
-    public function testDoesNotCreateLinksForUnknownPaginationParamType()
+    public function testDoesNotCreateLinksForUnknownPaginationParamType(): void
     {
         $query = $this->mockQuery();
         $query->expects($this->once())
@@ -153,7 +162,7 @@ class DoctrinePaginatorTest extends TestCase
         $this->assertInstanceOf(HalResource::class, $resource);
     }
 
-    public function testCreatesLinksForQueryBasedPagination()
+    public function testCreatesLinksForQueryBasedPagination(): void
     {
         $query = $this->mockQuery();
         $query->expects($this->once())
@@ -222,7 +231,7 @@ class DoctrinePaginatorTest extends TestCase
         $this->assertInstanceOf(HalResource::class, $resource);
     }
 
-    public function testCreatesLinksForRouteBasedPagination()
+    public function testCreatesLinksForRouteBasedPagination(): void
     {
         $query = $this->mockQuery();
         $query->expects($this->once())

--- a/test/ResourceGenerator/NestedCollectionResourceGenerationTest.php
+++ b/test/ResourceGenerator/NestedCollectionResourceGenerationTest.php
@@ -36,7 +36,7 @@ class NestedCollectionResourceGenerationTest extends TestCase
 
     use ProphecyTrait;
 
-    public function testNestedCollectionIsEmbeddedAsAnArrayNotAHalCollection()
+    public function testNestedCollectionIsEmbeddedAsAnArrayNotAHalCollection(): void
     {
         $collection    = $this->createCollection();
         $foo           = new TestAsset\FooBar();
@@ -94,10 +94,9 @@ class NestedCollectionResourceGenerationTest extends TestCase
     }
 
     /**
-     * @return MetadataMap|ObjectProphecy
-     * @psalm-return MetadataMap&ObjectProphecy
+     * @psalm-return ObjectProphecy<MetadataMap>
      */
-    private function createMetadataMap()
+    private function createMetadataMap(): ObjectProphecy
     {
         $metadataMap = $this->prophesize(MetadataMap::class);
 
@@ -132,10 +131,9 @@ class NestedCollectionResourceGenerationTest extends TestCase
     }
 
     /**
-     * @return ContainerInterface|ObjectProphecy
-     * @psalm-return ContainerInterface&ObjectProphecy
+     * @psalm-return ObjectProphecy<ContainerInterface>
      */
-    private function createHydrators()
+    private function createHydrators(): ObjectProphecy
     {
         $hydratorClass = self::getObjectPropertyHydratorClass();
 
@@ -147,10 +145,9 @@ class NestedCollectionResourceGenerationTest extends TestCase
     /**
      * @param ServerRequestInterface|ObjectProphecy $request
      * @psalm-param ServerRequestInterface&ObjectProphecy $request
-     * @return LinkGenerator|ObjectProphecy
-     * @psalm-return LinkGenerator&ObjectProphecy
+     * @psalm-return ObjectProphecy<LinkGenerator>
      */
-    public function createLinkGenerator($request)
+    public function createLinkGenerator($request): ObjectProphecy
     {
         $linkGenerator = $this->prophesize(LinkGenerator::class);
 

--- a/test/ResourceGenerator/ResourceWithNestedInstancesTest.php
+++ b/test/ResourceGenerator/ResourceWithNestedInstancesTest.php
@@ -32,7 +32,7 @@ class ResourceWithNestedInstancesTest extends TestCase
 
     use ProphecyTrait;
 
-    public function testNestedObjectInMetadataMapIsEmbeddedAsResource()
+    public function testNestedObjectInMetadataMapIsEmbeddedAsResource(): void
     {
         $child          = new TestAsset\Child();
         $child->id      = 9876;
@@ -75,10 +75,9 @@ class ResourceWithNestedInstancesTest extends TestCase
     }
 
     /**
-     * @return MetadataMap|ObjectProphecy
-     * @psalm-return MetadataMap&ObjectProphecy
+     * @psalm-return ObjectProphecy<MetadataMap>
      */
-    public function createMetadataMap()
+    public function createMetadataMap(): ObjectProphecy
     {
         $metadataMap = $this->prophesize(MetadataMap::class);
 
@@ -106,10 +105,9 @@ class ResourceWithNestedInstancesTest extends TestCase
     /**
      * @param ServerRequestInterface|ObjectProphecy $request
      * @psalm-param ServerRequestInterface&ObjectProphecy $request
-     * @return LinkGenerator|ObjectProphecy
-     * @psalm-return LinkGenerator&ObjectProphecy
+     * @psalm-return ObjectProphecy<LinkGenerator>
      */
-    public function createLinkGenerator($request)
+    public function createLinkGenerator($request): ObjectProphecy
     {
         $linkGenerator = $this->prophesize(LinkGenerator::class);
 
@@ -141,10 +139,9 @@ class ResourceWithNestedInstancesTest extends TestCase
     }
 
     /**
-     * @return ContainerInterface|ObjectProphecy
-     * @psalm-return ContainerInterface&ObjectProphecy
+     * @psalm-return ObjectProphecy<ContainerInterface>
      */
-    public function createHydrators()
+    public function createHydrators(): ObjectProphecy
     {
         $hydratorClass = self::getObjectPropertyHydratorClass();
 

--- a/test/ResourceGenerator/RouteBasedCollectionWithRouteParamsTest.php
+++ b/test/ResourceGenerator/RouteBasedCollectionWithRouteParamsTest.php
@@ -36,7 +36,7 @@ class RouteBasedCollectionWithRouteParamsTest extends TestCase
 
     use ProphecyTrait;
 
-    public function testUsesRouteParamsAndQueriesWithPaginatorSpecifiedInMetadataWhenGeneratingLinkHref()
+    public function testUsesRouteParamsAndQueriesWithPaginatorSpecifiedInMetadataWhenGeneratingLinkHref(): void
     {
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getAttribute('p', 1)->willReturn(3);
@@ -118,7 +118,7 @@ class RouteBasedCollectionWithRouteParamsTest extends TestCase
         $this->assertLink('last', '/api/foo/1234/p/5?sort=ASC', $last);
     }
 
-    public function testUsesRouteParamsAndQueriesSpecifiedInMetadataWhenGeneratingLinkHref()
+    public function testUsesRouteParamsAndQueriesSpecifiedInMetadataWhenGeneratingLinkHref(): void
     {
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getAttribute('param_1', 1)->willReturn(3);
@@ -201,7 +201,7 @@ class RouteBasedCollectionWithRouteParamsTest extends TestCase
      * @psalm-param LinkGenerator&ObjectProphecy $linkGenerator
      * @psalm-param ServerRequestInterface&ObjectProphecy $request
      */
-    private function createLinkGeneratorProphecy($linkGenerator, $request, string $rel, int $page)
+    private function createLinkGeneratorProphecy($linkGenerator, $request, string $rel, int $page): void
     {
         $linkGenerator->fromRoute(
             $rel,

--- a/test/ResourceGenerator/UrlBasedCollectionWithRouteParamsTest.php
+++ b/test/ResourceGenerator/UrlBasedCollectionWithRouteParamsTest.php
@@ -35,7 +35,7 @@ class UrlBasedCollectionWithRouteParamsTest extends TestCase
 
     use ProphecyTrait;
 
-    public function testUsesQueriesWithPaginatorSpecifiedInMetadataWhenGeneratingLinkHref()
+    public function testUsesQueriesWithPaginatorSpecifiedInMetadataWhenGeneratingLinkHref(): void
     {
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getQueryParams()->willReturn([
@@ -110,7 +110,7 @@ class UrlBasedCollectionWithRouteParamsTest extends TestCase
         $this->assertLink('last', 'http://test.local/collection/?query_1=value_1&p=5&sort=ASC', $last);
     }
 
-    public function testUsesQueriesSpecifiedInMetadataWhenGeneratingLinkHref()
+    public function testUsesQueriesSpecifiedInMetadataWhenGeneratingLinkHref(): void
     {
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getQueryParams()->willReturn([

--- a/test/ResourceGeneratorFactoryTest.php
+++ b/test/ResourceGeneratorFactoryTest.php
@@ -45,7 +45,7 @@ class ResourceGeneratorFactoryTest extends TestCase
             ->willReturn($this->prophesize(LinkGenerator::class));
     }
 
-    public function testFactoryRaisesExceptionIfMetadataMapConfigIsNotAnArray()
+    public function testFactoryRaisesExceptionIfMetadataMapConfigIsNotAnArray(): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn(new stdClass());
@@ -103,7 +103,7 @@ class ResourceGeneratorFactoryTest extends TestCase
     /**
      * @dataProvider missingOrEmptyStrategiesConfiguration
      */
-    public function testFactoryWithoutAnyStrategies(array $config)
+    public function testFactoryWithoutAnyStrategies(array $config): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn($config);
@@ -134,7 +134,7 @@ class ResourceGeneratorFactoryTest extends TestCase
      * @dataProvider invalidStrategiesConfig
      * @param mixed $strategies
      */
-    public function testFactoryRaisesExceptionIfStrategiesConfigIsNonTraversable($strategies)
+    public function testFactoryRaisesExceptionIfStrategiesConfigIsNonTraversable($strategies): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([
@@ -152,7 +152,7 @@ class ResourceGeneratorFactoryTest extends TestCase
         $factory($this->container->reveal());
     }
 
-    public function testFactoryWithRouteBasedCollectionStrategy()
+    public function testFactoryWithRouteBasedCollectionStrategy(): void
     {
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn(
@@ -185,7 +185,7 @@ class ResourceGeneratorFactoryTest extends TestCase
         );
     }
 
-    public function testConstructorAllowsSpecifyingLinkGeneratorServiceName()
+    public function testConstructorAllowsSpecifyingLinkGeneratorServiceName(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -212,7 +212,7 @@ class ResourceGeneratorFactoryTest extends TestCase
         $this->assertAttributeSame($linkGenerator, 'linkGenerator', $generator);
     }
 
-    public function testFactoryIsSerializable()
+    public function testFactoryIsSerializable(): void
     {
         $factory = ResourceGeneratorFactory::__set_state([
             'linkGeneratorServiceName' => CustomLinkGenerator::class,

--- a/test/ResourceGeneratorTest.php
+++ b/test/ResourceGeneratorTest.php
@@ -92,12 +92,12 @@ class ResourceGeneratorTest extends TestCase
         );
     }
 
-    public function testResourceGeneratorImplementsInterface()
+    public function testResourceGeneratorImplementsInterface(): void
     {
         $this->assertInstanceOf(ResourceGeneratorInterface::class, $this->generator);
     }
 
-    public function testCanGenerateResourceWithSelfLinkFromArrayData()
+    public function testCanGenerateResourceWithSelfLinkFromArrayData(): void
     {
         $data = [
             'foo' => 'bar',
@@ -115,7 +115,7 @@ class ResourceGeneratorTest extends TestCase
         $this->assertEquals($data, $resource->getElements());
     }
 
-    public function testCanGenerateUrlBasedResourceFromObjectDefinedInMetadataMap()
+    public function testCanGenerateUrlBasedResourceFromObjectDefinedInMetadataMap(): void
     {
         $instance      = new TestAsset\FooBar();
         $instance->id  = 'XXXX-YYYY-ZZZZ';
@@ -150,7 +150,7 @@ class ResourceGeneratorTest extends TestCase
         ], $resource->getElements());
     }
 
-    public function testCanGenerateRouteBasedResourceFromObjectDefinedInMetadataMap()
+    public function testCanGenerateRouteBasedResourceFromObjectDefinedInMetadataMap(): void
     {
         $instance      = new TestAsset\FooBar();
         $instance->id  = 'XXXX-YYYY-ZZZZ';
@@ -200,7 +200,7 @@ class ResourceGeneratorTest extends TestCase
         ], $resource->getElements());
     }
 
-    public function testCanGenerateUrlBasedCollectionFromObjectDefinedInMetadataMap()
+    public function testCanGenerateUrlBasedCollectionFromObjectDefinedInMetadataMap(): void
     {
         $first      = new TestAsset\FooBar();
         $first->id  = 'XXXX-YYYY-ZZZZ';
@@ -266,7 +266,7 @@ class ResourceGeneratorTest extends TestCase
         ], $ids);
     }
 
-    public function testCanGenerateRouteBasedCollectionFromObjectDefinedInMetadataMap()
+    public function testCanGenerateRouteBasedCollectionFromObjectDefinedInMetadataMap(): void
     {
         $instance      = new TestAsset\FooBar();
         $instance->foo = 'BAR';
@@ -398,7 +398,7 @@ class ResourceGeneratorTest extends TestCase
         }
     }
 
-    public function testGeneratedRouteBasedCollectionCastsPaginationMetadataToIntegers()
+    public function testGeneratedRouteBasedCollectionCastsPaginationMetadataToIntegers(): void
     {
         $instance      = new TestAsset\FooBar();
         $instance->foo = 'BAR';
@@ -508,7 +508,7 @@ class ResourceGeneratorTest extends TestCase
         $this->assertSame(5, $resource->getElement('_page_count'));
     }
 
-    public function testGeneratorDoesNotAcceptPageQueryOutOfBounds()
+    public function testGeneratorDoesNotAcceptPageQueryOutOfBounds(): void
     {
         $instance      = new TestAsset\FooBar();
         $instance->foo = 'BAR';
@@ -564,7 +564,7 @@ class ResourceGeneratorTest extends TestCase
         $this->generator->fromObject($collection, $this->request->reveal());
     }
 
-    public function testGeneratorDoesNotAcceptNegativePageQuery()
+    public function testGeneratorDoesNotAcceptNegativePageQuery(): void
     {
         $instance      = new TestAsset\FooBar();
         $instance->foo = 'BAR';
@@ -620,7 +620,7 @@ class ResourceGeneratorTest extends TestCase
         $this->generator->fromObject($collection, $this->request->reveal());
     }
 
-    public function testGeneratorAcceptsOnePageWhenCollectionHasNoEmbedded()
+    public function testGeneratorAcceptsOnePageWhenCollectionHasNoEmbedded(): void
     {
         $instance      = new TestAsset\FooBar();
         $instance->foo = 'BAR';
@@ -669,7 +669,7 @@ class ResourceGeneratorTest extends TestCase
         $this->assertEquals(0, $resource->getElement('_page_count'));
     }
 
-    public function testGeneratorRaisesExceptionForUnknownObjectType()
+    public function testGeneratorRaisesExceptionForUnknownObjectType(): void
     {
         $this->metadataMap->has(self::class)->willReturn(false);
         $this->expectException(InvalidObjectException::class);
@@ -705,7 +705,7 @@ class ResourceGeneratorTest extends TestCase
      * @dataProvider strategyCollection
      * @dataProvider strategyResource
      */
-    public function testUnexpectedMetadataForStrategy(ResourceGenerator\StrategyInterface $strategy)
+    public function testUnexpectedMetadataForStrategy(ResourceGenerator\StrategyInterface $strategy): void
     {
         $this->generator->addStrategy(
             TestMetadata::class,
@@ -730,7 +730,7 @@ class ResourceGeneratorTest extends TestCase
     public function testNotTraversableInstanceForCollectionStrategy(
         ResourceGenerator\StrategyInterface $strategy,
         string $metadata
-    ) {
+    ): void {
         $collectionMetadata = new $metadata(
             TestAsset\FooBar::class,
             'foo-bar',
@@ -747,21 +747,21 @@ class ResourceGeneratorTest extends TestCase
         $this->generator->fromObject($instance, $this->request->reveal());
     }
 
-    public function testAddStrategyRaisesExceptionIfInvalidMetadataClass()
+    public function testAddStrategyRaisesExceptionIfInvalidMetadataClass(): void
     {
         $this->expectException(UnknownMetadataTypeException::class);
         $this->expectExceptionMessage('does not exist, or does not extend');
         $this->generator->addStrategy(stdClass::class, 'invalid-strategy');
     }
 
-    public function testAddStrategyRaisesExceptionIfInvalidStrategyClass()
+    public function testAddStrategyRaisesExceptionIfInvalidStrategyClass(): void
     {
         $this->expectException(InvalidStrategyException::class);
         $this->expectExceptionMessage('does not exist, or does not implement');
         $this->generator->addStrategy(TestMetadata::class, 'invalid-strategy');
     }
 
-    public function testPassesAllScalarEntityPropertiesAsRouteParametersWhenGeneratingUri()
+    public function testPassesAllScalarEntityPropertiesAsRouteParametersWhenGeneratingUri(): void
     {
         $instance      = new TestAsset\FooBar();
         $instance->id  = 'XXXX-YYYY-ZZZZ';
@@ -806,7 +806,7 @@ class ResourceGeneratorTest extends TestCase
         $this->assertLink('self', '/api/foo-bar/XXXX-YYYY-ZZZZ', $self);
     }
 
-    public function testUsesConfiguredRoutePlaceholderMapToSpecifyRouteParams()
+    public function testUsesConfiguredRoutePlaceholderMapToSpecifyRouteParams(): void
     {
         $instance      = new TestAsset\FooBar();
         $instance->id  = 'XXXX-YYYY-ZZZZ';


### PR DESCRIPTION
- Adds Psalm and psalm PHPUnit plugin as dev requirements.
- Adds Psalm configuration.
- Fixes low-hanging fruit reported by Psalm.
- Adds Psalm baseline file.

Among the low-hanging fruit were the following `LinkCollection` signature changes:

- `getLinks()` gets an `array` return typehint
- `getLinksByRel()` gets an `array` return typehint
- `withLink()` gets a `self` return typehint
- `withoutLink()` gets a `self` return typehint

These are all backwards compatible, but extensions will need to provide them.

Fixes #17
