### PR TITLE
Fix broken mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,8 +18,8 @@ nav:
         - "Representations": v2/representations.md
         - "Generating HAL for Doctrine Entities": v2/doctrine.md
         - "Factories": v2/factories.md
-    - Migration:
-        - "Migration from V1": v2/migration.md
+      - Migration:
+          - "Migration from V1": v2/migration.md
       - Cookbook:
           - "Generating Custom Links In Middleware and Request Handlers": v2/cookbook/generating-custom-links-in-middleware.md
           - "Using the ResourceGenerator in path-segregated middleware": v2/cookbook/path-segregated-uri-generation.md


### PR DESCRIPTION
Fixes indentation of the `Migration` section of the `mkdocs.yml` so that it parses correctly.
