### PR TITLE
Support empty collections in `_embedded` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@
 [![Build Status](https://github.com/mezzio/mezzio-hal/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/mezzio/mezzio-hal/actions/workflows/continuous-integration.yml)
 
 > ## 🇷🇺 Русским гражданам
-> 
+>
 > Мы, участники Laminas, родились и живем в разных странах. У многих из нас есть друзья, родственники и коллеги как в России, так и в Украине. Некоторые из нас родились в России. Некоторые из нас живут в России. У некоторых бабушки и дедушки сражались с фашистами во Второй мировой войне. Здесь никто не поддерживает фашизм.
-> 
+>
 > У одного из нас есть украинская родственница, которая спаслась из дома вместе с сыном. Поезд задержался из-за бомбежки на дороге впереди. У нас есть друзья, которые прячутся в бомбоубежищах. Мы с тревогой ждем весточки от них после воздушных налетов, которые беспорядочно наносят удары и попадают по больницам, школам, детским садам и домам. Мы не берем это из каких-либо СМИ. Мы наблюдаем это напрямую.
-> 
+>
 > Вы доверяете нам достаточно, чтоб использовать наши программы, и мы просим вас довериться нам вновь. Мы нуждаемся в помощи. Выходите и протестуйте против этой бесполезной войны. Остановите кровопролитие. Скажите "Нет войне!"
-> 
+>
 > ## 🇺🇸 To Citizens of Russia
-> 
+>
 > We at Laminas come from all over the world. Many of us have friends, family and colleagues in both Russia and Ukraine. Some of us were born in Russia. Some of us currently live in Russia. Some have grandparents who fought Nazis in World War II. Nobody here supports fascism.
-> 
+>
 > One team member has a Ukrainian relative who fled her home with her son. The train was delayed due to bombing on the road ahead. We have friends who are hiding in bomb shelters. We anxiously follow up on them after the air raids, which indiscriminately fire at hospitals, schools, kindergartens and houses. We're not taking this from any media. These are our actual experiences.
-> 
+>
 > You trust us enough to use our software. We ask that you trust us to say the truth on this. We need your help. Go out and protest this unnecessary war. Stop the bloodshed. Say "stop the war!"
 
 This library provides utilities for modeling HAL resources with links and generating [PSR-7](https://www.php-fig.org/psr/psr-7/) responses representing both JSON and XML serializations of them.

--- a/docs/book/v2/links-and-resources.md
+++ b/docs/book/v2/links-and-resources.md
@@ -230,7 +230,6 @@ When `embed-empty-collections` is set to `false`, the representation will be as 
 
 However, when `embed-empty-collections` is set to `true`, the representation will be as follows:
 
-**`empty-contacts-collection-embedded.json`**
 
 ```json
 {

--- a/docs/book/v2/links-and-resources.md
+++ b/docs/book/v2/links-and-resources.md
@@ -221,7 +221,6 @@ The default setting of `false` ensures compatibility with existing API endpoints
 
 When `embed-empty-collections` is set to `false`, the representation will be as follows:
 
-
 ```json
 {
   "contacts": []
@@ -229,7 +228,6 @@ When `embed-empty-collections` is set to `false`, the representation will be as 
 ```
 
 However, when `embed-empty-collections` is set to `true`, the representation will be as follows:
-
 
 ```json
 {

--- a/docs/book/v2/links-and-resources.md
+++ b/docs/book/v2/links-and-resources.md
@@ -198,4 +198,42 @@ $resource = $resource->withLink($link);
 $resource = $resource->withoutLink($link);
 ```
 
+To maintain consistency in the structure of the response, you may choose to embed both non-empty and empty collections within the `_embedded` section. This can be achieved by enabling the `embed-empty-collections` configuration option.
+
+To enable this feature, modify the configuration file as follows:
+
+```php
+return [
+    'mezzio-hal' => [
+        'embed-empty-collections' => false, // (default: false for compatibility reasons)
+        'metadata-factories' => [...],
+        'resource-generator' => [...],
+    ],
+];
+```
+
+The default setting of `false` ensures compatibility with existing API endpoints and prevents potential test failures.
+
+When `embed-empty-collections` is set to `false`, the representation will be as follows:
+
+**`empty-contacts-collection-not-embedded.json`**
+
+```json
+{
+  "contacts": []
+}
+```
+
+However, when `embed-empty-collections` is set to `true`, the representation will be as follows:
+
+**`empty-contacts-collection-embedded.json`**
+
+``` json
+{
+  "_embedded": {
+    "contacts": []
+  }
+}
+```
+
 With these tools, you can describe any resource you want to represent.

--- a/docs/book/v2/links-and-resources.md
+++ b/docs/book/v2/links-and-resources.md
@@ -228,7 +228,7 @@ However, when `embed-empty-collections` is set to `true`, the representation wil
 
 **`empty-contacts-collection-embedded.json`**
 
-``` json
+```json
 {
   "_embedded": {
     "contacts": []

--- a/docs/book/v2/links-and-resources.md
+++ b/docs/book/v2/links-and-resources.md
@@ -198,9 +198,10 @@ $resource = $resource->withLink($link);
 $resource = $resource->withoutLink($link);
 ```
 
-> INFO: Available since 2.7.0
->
-> The `embed-empty-collections` configuration option is available starting with version 2.7.0.
+### Embed Empty Collection
+
+> INFO: **New Feature**
+> Available since version 2.7.0.
 
 To maintain consistency in the structure of the response, you may choose to embed both non-empty and empty collections within the `_embedded` section. This can be achieved by enabling the `embed-empty-collections` configuration option.
 

--- a/docs/book/v2/links-and-resources.md
+++ b/docs/book/v2/links-and-resources.md
@@ -198,6 +198,10 @@ $resource = $resource->withLink($link);
 $resource = $resource->withoutLink($link);
 ```
 
+> INFO: Available since 2.7.0
+>
+> The `embed-empty-collections` configuration option is available starting with version 2.7.0.
+
 To maintain consistency in the structure of the response, you may choose to embed both non-empty and empty collections within the `_embedded` section. This can be achieved by enabling the `embed-empty-collections` configuration option.
 
 To enable this feature, modify the configuration file `config/autoload/hal.global.php` as follows:

--- a/docs/book/v2/links-and-resources.md
+++ b/docs/book/v2/links-and-resources.md
@@ -200,7 +200,7 @@ $resource = $resource->withoutLink($link);
 
 To maintain consistency in the structure of the response, you may choose to embed both non-empty and empty collections within the `_embedded` section. This can be achieved by enabling the `embed-empty-collections` configuration option.
 
-To enable this feature, modify the configuration file as follows:
+To enable this feature, modify the configuration file `config/autoload/hal.global.php` as follows:
 
 ```php
 return [

--- a/docs/book/v2/links-and-resources.md
+++ b/docs/book/v2/links-and-resources.md
@@ -220,7 +220,6 @@ The default setting of `false` ensures compatibility with existing API endpoints
 
 When `embed-empty-collections` is set to `false`, the representation will be as follows:
 
-**`empty-contacts-collection-not-embedded.json`**
 
 ```json
 {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -448,9 +448,6 @@
     </MixedArrayOffset>
   </file>
   <file src="src/ResourceGenerator/UrlBasedCollectionStrategy.php">
-    <InvalidArgument>
-      <code>$page</code>
-    </InvalidArgument>
     <MethodSignatureMismatch>
       <code>protected function generateSelfLink(</code>
     </MethodSignatureMismatch>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -69,6 +69,13 @@ class ConfigProvider
     public function getHalConfig(): array
     {
         return [
+            /** 
+             * Whether or not to include empty collections within the _embedded section of the response,
+             *
+             * See: https://github.com/mezzio/mezzio-hal/pull/80
+             */
+            'embed-empty-collections' => false,
+            
             'resource-generator' => [
                 'strategies' => [ // The registered strategies and their metadata types
                     RouteBasedCollectionMetadata::class => RouteBasedCollectionStrategy::class,

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -69,11 +69,6 @@ class ConfigProvider
     public function getHalConfig(): array
     {
         return [
-            /**
-             * Whether or not to include empty collections within the _embedded section of the response,
-             *
-             * See: https://github.com/mezzio/mezzio-hal/pull/80
-             */
             'embed-empty-collections' => false,
             'resource-generator'      => [
                 'strategies' => [ // The registered strategies and their metadata types

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -69,14 +69,13 @@ class ConfigProvider
     public function getHalConfig(): array
     {
         return [
-            /** 
+            /**
              * Whether or not to include empty collections within the _embedded section of the response,
              *
              * See: https://github.com/mezzio/mezzio-hal/pull/80
              */
             'embed-empty-collections' => false,
-            
-            'resource-generator' => [
+            'resource-generator'      => [
                 'strategies' => [ // The registered strategies and their metadata types
                     RouteBasedCollectionMetadata::class => RouteBasedCollectionStrategy::class,
                     RouteBasedResourceMetadata::class   => RouteBasedResourceStrategy::class,
@@ -84,7 +83,7 @@ class ConfigProvider
                     UrlBasedResourceMetadata::class     => UrlBasedResourceStrategy::class,
                 ],
             ],
-            'metadata-factories' => [ // The factories for the metadata types
+            'metadata-factories'      => [ // The factories for the metadata types
                 RouteBasedCollectionMetadata::class => RouteBasedCollectionMetadataFactory::class,
                 RouteBasedResourceMetadata::class   => RouteBasedResourceMetadataFactory::class,
                 UrlBasedCollectionMetadata::class   => UrlBasedCollectionMetadataFactory::class,

--- a/src/HalResource.php
+++ b/src/HalResource.php
@@ -141,6 +141,10 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
     {
         $this->validateElementName($name, __METHOD__);
 
+        if ($value === null || $value === []) {
+            return $this->embed($name, []);
+        }
+
         if (
             ! empty($value)
             && ($value instanceof self || $this->isResourceCollection($value))

--- a/src/HalResource.php
+++ b/src/HalResource.php
@@ -42,8 +42,6 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
     /** @var array<array-key, self|array<array-key, self>> */
     private $embedded = [];
 
-    private bool $embedEmptyCollections;
-
     /**
      * @param array $data
      * @param LinkInterface[] $links
@@ -53,7 +51,7 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
         array $data = [],
         array $links = [],
         array $embedded = [],
-        bool $embedEmptyCollections = false
+        private bool $embedEmptyCollections = false
     ) {
         $this->embedEmptyCollections = $embedEmptyCollections;
 

--- a/src/HalResource.php
+++ b/src/HalResource.php
@@ -49,8 +49,12 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
      * @param LinkInterface[] $links
      * @param HalResource[][] $embedded
      */
-    public function __construct(array $data = [], array $links = [], array $embedded = [], bool $embedEmptyCollections = false)
-    {
+    public function __construct(
+        array $data = [],
+        array $links = [],
+        array $embedded = [],
+        bool $embedEmptyCollections = false
+    ) {
         $this->embedEmptyCollections = $embedEmptyCollections;
 
         $context = self::class;

--- a/src/ResourceGenerator.php
+++ b/src/ResourceGenerator.php
@@ -94,6 +94,7 @@ class ResourceGenerator implements ResourceGeneratorInterface
 
     public function fromArray(array $data, ?string $uri = null): HalResource
     {
+        /** @psalm-suppress MixedArrayAccess */
         $embedEmptyCollections =
             $this->hydrators->has('config') &&
             $this->hydrators->get('config')['mezzio-hal']['embed-empty-collections'] ??

--- a/src/ResourceGenerator.php
+++ b/src/ResourceGenerator.php
@@ -96,9 +96,8 @@ class ResourceGenerator implements ResourceGeneratorInterface
     {
         /** @psalm-suppress MixedArrayAccess */
         $embedEmptyCollections =
-            $this->hydrators->has('config') &&
-            $this->hydrators->get('config')['mezzio-hal']['embed-empty-collections'] ??
-            false;
+            $this->hydrators->has('config')
+            && $this->hydrators->get('config')['mezzio-hal']['embed-empty-collections'] ?? false;
 
         $resource = new HalResource($data, [], [], $embedEmptyCollections);
 

--- a/src/ResourceGenerator.php
+++ b/src/ResourceGenerator.php
@@ -94,7 +94,12 @@ class ResourceGenerator implements ResourceGeneratorInterface
 
     public function fromArray(array $data, ?string $uri = null): HalResource
     {
-        $resource = new HalResource($data);
+        $embedEmptyCollections =
+            $this->hydrators->has('config') &&
+            $this->hydrators->get('config')['mezzio-hal']['embed-empty-collections'] ??
+            false;
+
+        $resource = new HalResource($data, [], [], $embedEmptyCollections);
 
         if (null !== $uri) {
             return $resource->withLink(new Link('self', $uri));

--- a/src/ResourceGenerator/UrlBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/UrlBasedCollectionStrategy.php
@@ -73,7 +73,7 @@ class UrlBasedCollectionStrategy implements StrategyInterface
 
         switch ($paginationType) {
             case Metadata\AbstractCollectionMetadata::TYPE_PLACEHOLDER:
-                $url = str_replace($url, $paginationParam, $page);
+                $url = str_replace($url, $paginationParam, (string) $page);
                 break;
             case Metadata\AbstractCollectionMetadata::TYPE_QUERY:
                 // fall-through

--- a/test/Fixture/empty-contacts-collection.json
+++ b/test/Fixture/empty-contacts-collection.json
@@ -1,0 +1,10 @@
+{
+  "_links": {
+    "self": {
+      "href": "/api/contacts"
+    }
+  },
+  "_embedded": {
+    "contacts": []
+  }
+}

--- a/test/Fixture/non-empty-contacts-collection.json
+++ b/test/Fixture/non-empty-contacts-collection.json
@@ -1,0 +1,21 @@
+{
+  "_links": {
+    "self": {
+      "href": "/api/contacts"
+    }
+  },
+  "_embedded": {
+    "contacts": [
+      {
+        "id": 1,
+        "name": "John",
+        "email": "john@example.com"
+      },
+      {
+        "id": 2,
+        "name": "Jane",
+        "email": "jane@example.com"
+      }
+    ]
+  }
+}

--- a/test/Fixture/null-contacts-collection.json
+++ b/test/Fixture/null-contacts-collection.json
@@ -1,0 +1,8 @@
+{
+  "contacts": null,
+  "_links": {
+    "self": {
+      "href": "/api/contacts"
+    }
+  }
+}

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -239,7 +239,7 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => $collection], $new->getElements());
     }
 
-    public function testWithElementWillEmbedAnEmptyArrayIfAnEmptyArrayValueIsProvided(): void
+    public function testWithElementWillEmbedAnEmptyArrayIfAnEmptyArrayValueIsProvidedAndConfiguredToEmbedEmptyCollections(): void
     {
         $resource = new HalResource(['foo' => 'bar'], [], [], true);
         $new      = $resource->withElement('bar', []);

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -657,7 +657,12 @@ class HalResourceTest extends TestCase
             throw new RuntimeException('Failed to read fixture file: ' . $file);
         }
 
-        return json_decode($contents, true);
+        $json = json_decode($contents, true);
+        if (!is_array($json)) {
+            throw new RuntimeException('Failed to json_decode fixture file: ' . $file);
+        }
+
+        return $json;
     }
 
     /**

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -241,20 +241,20 @@ class HalResourceTest extends TestCase
 
     public function testWithElementWillEmbedAnEmptyArrayIfAnEmptyArrayValueIsProvided(): void
     {
-        $resource = new HalResource(['foo' => 'bar']);
+        $resource = new HalResource(['foo' => 'bar'], [], [], true);
         $new      = $resource->withElement('bar', []);
 
         $representation = $new->toArray();
         self::assertSame(['foo' => 'bar', '_embedded' => ['bar' => []]], $representation);
     }
 
-    public function testWithElementWillEmbedAnEmptyArrayIfNullValueIsProvided(): void
+    public function testWithElementDoesNotProxyToEmbedIfNullValueIsProvided(): void
     {
-        $resource = new HalResource(['foo' => 'bar']);
+        $resource = new HalResource(['foo' => 'bar'], [], [], true);
         $new      = $resource->withElement('bar', null);
 
         $representation = $new->toArray();
-        self::assertSame(['foo' => 'bar', '_embedded' => ['bar' => []]], $representation);
+        self::assertSame(['foo' => 'bar', 'bar' => null], $representation);
     }
 
     /**
@@ -690,12 +690,11 @@ class HalResourceTest extends TestCase
     }
 
     /**
-     * @return Generator<'array'|'null',list{array<never,never>|null},mixed,void>
+     * @return Generator<'array',list{array<never,never>},mixed,void>
      */
     public static function emptyCollectionDataProvider(): Generator
     {
         yield from [
-            'null'  => [null],
             'array' => [[]],
         ];
     }
@@ -705,7 +704,7 @@ class HalResourceTest extends TestCase
      */
     public function testEmptyCollection(mixed $collection): void
     {
-        $resource = (new HalResource())
+        $resource = (new HalResource([], [], [], true))
             ->withLink(new Link('self', '/api/contacts'))
             ->withElements(['contacts' => $collection]);
 
@@ -726,6 +725,31 @@ class HalResourceTest extends TestCase
 
         self::assertSame(
             $this->fixture('non-empty-contacts-collection.json'),
+            $resource->toArray()
+        );
+    }
+
+    /**
+     * @return Generator<'null',list{null},mixed,void>
+     */
+    public static function nullCollectionDataProvider(): Generator
+    {
+        yield from [
+            'null' => [null],
+        ];
+    }
+
+    /**
+     * @dataProvider nullCollectionDataProvider
+     */
+    public function testNullCollection(mixed $collection): void
+    {
+        $resource = (new HalResource([], [], [], true))
+            ->withLink(new Link('self', '/api/contacts'))
+            ->withElements(['contacts' => $collection]);
+
+        self::assertSame(
+            $this->fixture('null-contacts-collection.json'),
             $resource->toArray()
         );
     }

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -239,9 +239,18 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => $collection], $new->getElements());
     }
 
+    public function testWithElementDoesNotProxyToEmbedIfAnEmptyArrayValueIsProvided(): void
+    {
+        $resource = new HalResource(['foo' => 'bar'], embedEmptyCollections: false);
+        $new      = $resource->withElement('bar', []);
+
+        $representation = $new->toArray();
+        self::assertSame(['foo' => 'bar', 'bar' => []], $representation);
+    }
+
     public function testWithElementWillEmbedAnEmptyArrayIfAnEmptyArrayValueIsProvidedAndConfiguredToEmbedEmptyCollections(): void
     {
-        $resource = new HalResource(['foo' => 'bar'], [], [], true);
+        $resource = new HalResource(['foo' => 'bar'], embedEmptyCollections: true);
         $new      = $resource->withElement('bar', []);
 
         $representation = $new->toArray();

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MezzioTest\Hal;
 
+use Generator;
 use InvalidArgumentException;
 use Mezzio\Hal\HalResource;
 use Mezzio\Hal\Link;
@@ -659,7 +660,10 @@ class HalResourceTest extends TestCase
         return json_decode($contents, true);
     }
 
-    public static function nonEmptyCollectionDataProvider(): iterable
+    /**
+     * @return Generator<string,array<array-key,array<array-key,HalResource>>>
+     */
+    public static function nonEmptyCollectionDataProvider(): Generator
     {
         yield from [
             'collection' => [
@@ -679,7 +683,10 @@ class HalResourceTest extends TestCase
         ];
     }
 
-    public static function emptyCollectionDataProvider(): iterable
+    /**
+     * @return Generator<'array'|'null',list{array<never,never>|null},mixed,void>
+     */
+    public static function emptyCollectionDataProvider(): Generator
     {
         yield from [
             'null'  => [null],

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -752,7 +752,7 @@ class HalResourceTest extends TestCase
     /**
      * @dataProvider nullCollectionDataProvider
      */
-    public function testNullCollectionWhenEmbedEmtpyEnabled(mixed $collection): void
+    public function testNullCollectionWhenEmbedEmptyEnabled(mixed $collection): void
     {
         $resource = (new HalResource([], [], [], true))
             ->withLink(new Link('self', '/api/contacts'))

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -742,7 +742,7 @@ class HalResourceTest extends TestCase
     /**
      * @dataProvider nullCollectionDataProvider
      */
-    public function testNullCollection(mixed $collection): void
+    public function testNullCollectionWhenEmbedEmtpyEnabled(mixed $collection): void
     {
         $resource = (new HalResource([], [], [], true))
             ->withLink(new Link('self', '/api/contacts'))

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -13,6 +13,7 @@ use RuntimeException;
 
 use function array_values;
 use function file_get_contents;
+use function is_array;
 use function json_decode;
 
 class HalResourceTest extends TestCase
@@ -658,7 +659,7 @@ class HalResourceTest extends TestCase
         }
 
         $json = json_decode($contents, true);
-        if (!is_array($json)) {
+        if (! is_array($json)) {
             throw new RuntimeException('Failed to json_decode fixture file: ' . $file);
         }
 

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -248,7 +248,7 @@ class HalResourceTest extends TestCase
         self::assertSame(['foo' => 'bar', '_embedded' => ['bar' => []]], $representation);
     }
 
-    public function testWithElementDoesNotProxyToEmbedIfNullValueIsProvided(): void
+    public function testWithElementDoesNotProxyToEmbedIfNullValueIsProvidedAndEmbedEmptyCollectionsEnabled(): void
     {
         $resource = new HalResource(['foo' => 'bar'], [], [], true);
         $new      = $resource->withElement('bar', null);

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -248,6 +248,7 @@ class HalResourceTest extends TestCase
         self::assertSame(['foo' => 'bar', 'bar' => []], $representation);
     }
 
+    // phpcs:ignore
     public function testWithElementWillEmbedAnEmptyArrayIfAnEmptyArrayValueIsProvidedAndConfiguredToEmbedEmptyCollections(): void
     {
         $resource = new HalResource(['foo' => 'bar'], embedEmptyCollections: true);

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -237,13 +237,22 @@ class HalResourceTest extends TestCase
         $this->assertEquals(['foo' => $collection], $new->getElements());
     }
 
-    public function testWithElementDoesNotProxyToEmbedIfAnEmptyArrayValueIsProvided(): void
+    public function testWithElementWillEmbedAnEmptyArrayIfAnEmptyArrayValueIsProvided(): void
     {
         $resource = new HalResource(['foo' => 'bar']);
         $new      = $resource->withElement('bar', []);
 
         $representation = $new->toArray();
-        $this->assertEquals(['foo' => 'bar', 'bar' => []], $representation);
+        self::assertSame(['foo' => 'bar', '_embedded' => ['bar' => []]], $representation);
+    }
+
+    public function testWithElementWillEmbedAnEmptyArrayIfNullValueIsProvided(): void
+    {
+        $resource = new HalResource(['foo' => 'bar']);
+        $new      = $resource->withElement('bar', null);
+
+        $representation = $new->toArray();
+        self::assertSame(['foo' => 'bar', '_embedded' => ['bar' => []]], $representation);
     }
 
     /**

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -702,7 +702,7 @@ class HalResourceTest extends TestCase
     /**
      * @dataProvider emptyCollectionDataProvider
      */
-    public function testEmptyCollection(mixed $collection): void
+    public function testEmptyCollectionWhenEmbedEmptyEnabled(mixed $collection): void
     {
         $resource = (new HalResource([], [], [], true))
             ->withLink(new Link('self', '/api/contacts'))

--- a/test/ResourceGeneratorTest.php
+++ b/test/ResourceGeneratorTest.php
@@ -109,6 +109,9 @@ class ResourceGeneratorTest extends TestCase
             'foo' => 'bar',
             'bar' => 'baz',
         ];
+
+        $this->hydrators->has('config')->willReturn(false);
+
         $this->linkGenerator->fromRoute()->shouldNotBeCalled();
         $this->metadataMap->has()->shouldNotBeCalled();
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

The goal/convention is to include both non-empty and empty collections within the `_embedded` section of the response, to maintain consistency in the structure of the response, regardless of whether the collection is empty or not.

Discussion: https://laminas.slack.com/archives/C4RF57B0E/p1686214950164379

Maybe Related #4

 ---

**`empty-contacts-collection-not-embedded.json`**
```json
{
  "contacts": []
}
```

**`empty-contacts-collection-embedded.json`**
```json
{
  "_embedded": {
    "contacts": []
  }
}
```

**`non-empty-contacts-collection.json`**

```json
{
  "_embedded": {
    "contacts": [
      {
        "id": 1,
        "name": "Jane",
        "email": "jane@example.com"
      },
      {
        "id": 2,
        "name": "John",
        "email": "john@example.com"
      }
    ]
  }
}
```

---

The user also explained that adding the code below to the constructor worked for them (in case we need to refactor the constructor)

```
if ($value === null || $value === []) {
    $this->embedded[$name] = [];
    return;
}
```