### PR TITLE
Ensure entities are correctly escaped in `XMLRenderer`

### DIFF
--- a/src/Renderer/XmlRenderer.php
+++ b/src/Renderer/XmlRenderer.php
@@ -126,8 +126,12 @@ class XmlRenderer implements RendererInterface
         }
 
         if (is_scalar($data)) {
-            $data = $this->normalizeConstantValue($data);
-            return $doc->createElement($name, (string) $data);
+            $data     = $this->normalizeConstantValue($data);
+            $element  = $doc->createElement($name);
+            $textNode = $doc->createTextNode((string) $data);
+            $element->appendChild($textNode);
+
+            return $element;
         }
 
         if (is_object($data)) {

--- a/test/Renderer/XmlRendererTest.php
+++ b/test/Renderer/XmlRendererTest.php
@@ -104,4 +104,19 @@ class XmlRendererTest extends TestCase
         $xml      = $renderer->render($resource);
         $this->assertStringContainsString('<key/>', $xml);
     }
+
+    public function testRendersStringsWithAmpersandsAsTagWithEscapedText(): void
+    {
+        $resource = new HalResource([
+            'some-text-tag' => 'https://some-domain.com/some-path?rb=0&mode=widget&appView=1',
+        ]);
+        $resource = $resource->withLink(new Link('self', '/example'));
+
+        $renderer = new XmlRenderer();
+        $xml      = $renderer->render($resource);
+        $this->assertStringContainsString(
+            '<some-text-tag>https://some-domain.com/some-path?rb=0&amp;mode=widget&amp;appView=1</some-text-tag>',
+            $xml
+        );
+    }
 }


### PR DESCRIPTION
Recreated from #97 courtesy of @tempfirstuser

- Closes #96 
