### PR TITLE
Refactor: enforce strict typing with rector

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,6 +6,21 @@ on:
     branches:
     tags:
 
+env:
+  default_php: 8.1
+
 jobs:
   ci:
     uses: laminas/workflow-continuous-integration/.github/workflows/continuous-integration.yml@1.x
+
+  rector:
+    runs-on: ubuntu-latest
+    name: Run Rector on PHP
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: shivammathur/setup-php@2.34.1
+        with:
+          php-version: ${{ env.default_php }}
+          tools: composer
+      - uses: ramsey/composer-install@v3
+      - run: composer rector

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "psr/container": "^1.1.2 || ^2.0.2",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0.1 || ^2.0.0",
-        "psr/link": "^1.0",
+        "psr/link": "^1.1",
         "webmozart/assert": "^1.10",
         "willdurand/negotiation": "^3.0"
     },
@@ -57,6 +57,7 @@
         "phpspec/prophecy-phpunit": "^2.2.0",
         "phpunit/phpunit": "^9.6.21",
         "psalm/plugin-phpunit": "^0.19.0",
+        "rector/rector": "^2.1",
         "vimeo/psalm": "^5.26.1"
     },
     "provide": {
@@ -85,7 +86,11 @@
         ],
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
+        "rector": "rector -n -vv",
+        "rector:fix": "rector -vv",
         "static-analysis": "psalm --shepherd --stats",
+        "static-analysis:b": "psalm --update-baseline",
+        "static-analysis:clear": "psalm --clear-cache",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6944b9a6395afd0144bec2ab54512975",
+    "content-hash": "ef7fe027c1d223747db0ac072f835a4c",
     "packages": [
         {
             "name": "psr/container",
@@ -571,16 +571,16 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.1",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "63aaeac21d7e775ff9bc9d45021e1745c97521c4"
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/63aaeac21d7e775ff9bc9d45021e1745c97521c4",
-                "reference": "63aaeac21d7e775ff9bc9d45021e1745c97521c4",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
                 "shasum": ""
             },
             "require": {
@@ -590,19 +590,19 @@
                 "phpstan/phpstan": "<1.11.10"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.11.10",
-                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
                 "phpunit/phpunit": "^8 || ^9"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                },
                 "phpstan": {
                     "includes": [
                         "extension.neon"
                     ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -630,7 +630,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.1"
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
             },
             "funding": [
                 {
@@ -646,7 +646,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-27T18:44:43+00:00"
+            "time": "2024-11-12T16:29:46+00:00"
         },
         {
             "name": "composer/semver",
@@ -1002,29 +1002,29 @@
         },
         {
             "name": "doctrine/collections",
-            "version": "2.2.2",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/collections.git",
-                "reference": "d8af7f248c74f195f7347424600fd9e17b57af59"
+                "reference": "2eb07e5953eed811ce1b309a7478a3b236f2273d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/collections/zipball/d8af7f248c74f195f7347424600fd9e17b57af59",
-                "reference": "d8af7f248c74f195f7347424600fd9e17b57af59",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/2eb07e5953eed811ce1b309a7478a3b236f2273d",
+                "reference": "2eb07e5953eed811ce1b309a7478a3b236f2273d",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1",
-                "php": "^8.1"
+                "php": "^8.1",
+                "symfony/polyfill-php84": "^1.30"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^12",
                 "ext-json": "*",
                 "phpstan/phpstan": "^1.8",
                 "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^10.5",
-                "vimeo/psalm": "^5.11"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "autoload": {
@@ -1068,7 +1068,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/collections/issues",
-                "source": "https://github.com/doctrine/collections/tree/2.2.2"
+                "source": "https://github.com/doctrine/collections/tree/2.3.0"
             },
             "funding": [
                 {
@@ -1084,24 +1084,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T06:56:21+00:00"
+            "time": "2025-03-22T10:17:19+00:00"
         },
         {
             "name": "doctrine/common",
-            "version": "3.4.5",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/common.git",
-                "reference": "6c8fef961f67b8bc802ce3e32e3ebd1022907286"
+                "reference": "d9ea4a54ca2586db781f0265d36bea731ac66ec5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/common/zipball/6c8fef961f67b8bc802ce3e32e3ebd1022907286",
-                "reference": "6c8fef961f67b8bc802ce3e32e3ebd1022907286",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/d9ea4a54ca2586db781f0265d36bea731ac66ec5",
+                "reference": "d9ea4a54ca2586db781f0265d36bea731ac66ec5",
                 "shasum": ""
             },
             "require": {
-                "doctrine/persistence": "^2.0 || ^3.0",
+                "doctrine/persistence": "^2.0 || ^3.0 || ^4.0",
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
@@ -1159,7 +1159,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/common/issues",
-                "source": "https://github.com/doctrine/common/tree/3.4.5"
+                "source": "https://github.com/doctrine/common/tree/3.5.0"
             },
             "funding": [
                 {
@@ -1175,44 +1175,45 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-08T15:53:43+00:00"
+            "time": "2025-01-01T22:12:03+00:00"
         },
         {
             "name": "doctrine/dbal",
-            "version": "3.9.3",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "61446f07fcb522414d6cfd8b1c3e5f9e18c579ba"
+                "reference": "1cf840d696373ea0d58ad0a8875c0fadcfc67214"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/61446f07fcb522414d6cfd8b1c3e5f9e18c579ba",
-                "reference": "61446f07fcb522414d6cfd8b1c3e5f9e18c579ba",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/1cf840d696373ea0d58ad0a8875c0fadcfc67214",
+                "reference": "1cf840d696373ea0d58ad0a8875c0fadcfc67214",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2",
-                "doctrine/cache": "^1.11|^2.0",
                 "doctrine/deprecations": "^0.5.3|^1",
                 "doctrine/event-manager": "^1|^2",
                 "php": "^7.4 || ^8.0",
                 "psr/cache": "^1|^2|^3",
                 "psr/log": "^1|^2|^3"
             },
+            "conflict": {
+                "doctrine/cache": "< 1.11"
+            },
             "require-dev": {
-                "doctrine/coding-standard": "12.0.0",
+                "doctrine/cache": "^1.11|^2.0",
+                "doctrine/coding-standard": "13.0.0",
                 "fig/log-test": "^1",
                 "jetbrains/phpstorm-stubs": "2023.1",
-                "phpstan/phpstan": "1.12.6",
-                "phpstan/phpstan-strict-rules": "^1.6",
-                "phpunit/phpunit": "9.6.20",
-                "psalm/plugin-phpunit": "0.18.4",
-                "slevomat/coding-standard": "8.13.1",
-                "squizlabs/php_codesniffer": "3.10.2",
+                "phpstan/phpstan": "2.1.17",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "9.6.23",
+                "slevomat/coding-standard": "8.16.2",
+                "squizlabs/php_codesniffer": "3.13.1",
                 "symfony/cache": "^5.4|^6.0|^7.0",
-                "symfony/console": "^4.4|^5.4|^6.0|^7.0",
-                "vimeo/psalm": "4.30.0"
+                "symfony/console": "^4.4|^5.4|^6.0|^7.0"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -1272,7 +1273,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/3.9.3"
+                "source": "https://github.com/doctrine/dbal/tree/3.10.0"
             },
             "funding": [
                 {
@@ -1288,33 +1289,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-10T17:56:43+00:00"
+            "time": "2025-07-10T21:11:04+00:00"
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.3",
+            "version": "1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab"
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
-                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=13"
+            },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
-                "phpstan/phpstan": "1.4.10 || 1.10.15",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "psalm/plugin-phpunit": "0.18.4",
-                "psr/log": "^1 || ^2 || ^3",
-                "vimeo/psalm": "4.30.0 || 5.12.0"
+                "doctrine/coding-standard": "^9 || ^12 || ^13",
+                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
                 "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
@@ -1322,7 +1324,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                    "Doctrine\\Deprecations\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1333,9 +1335,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.3"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
             },
-            "time": "2024-01-30T19:34:25+00:00"
+            "time": "2025-04-07T20:06:18+00:00"
         },
         {
             "name": "doctrine/event-manager",
@@ -1668,16 +1670,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "2.19.8",
+            "version": "2.20.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "c2c500077b1ec9d0a829fdf7c8d18e448b501605"
+                "reference": "6307b4fa7d7e3845a756106977e3b48907622098"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/c2c500077b1ec9d0a829fdf7c8d18e448b501605",
-                "reference": "c2c500077b1ec9d0a829fdf7c8d18e448b501605",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/6307b4fa7d7e3845a756106977e3b48907622098",
+                "reference": "6307b4fa7d7e3845a756106977e3b48907622098",
                 "shasum": ""
             },
             "require": {
@@ -1704,16 +1706,17 @@
             },
             "require-dev": {
                 "doctrine/annotations": "^1.13 || ^2",
-                "doctrine/coding-standard": "^9.0.2 || ^12.0",
+                "doctrine/coding-standard": "^9.0.2 || ^13.0",
                 "phpbench/phpbench": "^0.16.10 || ^1.0",
-                "phpstan/phpstan": "~1.4.10 || 1.12.6",
+                "phpstan/extension-installer": "~1.1.0 || ^1.4",
+                "phpstan/phpstan": "~1.4.10 || 2.0.3",
+                "phpstan/phpstan-deprecation-rules": "^1 || ^2",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6",
                 "psr/log": "^1 || ^2 || ^3",
-                "squizlabs/php_codesniffer": "3.7.2",
+                "squizlabs/php_codesniffer": "3.12.0",
                 "symfony/cache": "^4.4 || ^5.4 || ^6.4 || ^7.0",
                 "symfony/var-exporter": "^4.4 || ^5.4 || ^6.2 || ^7.0",
-                "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
-                "vimeo/psalm": "4.30.0 || 5.24.0"
+                "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
                 "ext-dom": "Provides support for XSD validation for XML mapping files",
@@ -1763,22 +1766,22 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/2.19.8"
+                "source": "https://github.com/doctrine/orm/tree/2.20.5"
             },
-            "time": "2024-10-10T09:46:49+00:00"
+            "time": "2025-06-24T17:50:46+00:00"
         },
         {
             "name": "doctrine/persistence",
-            "version": "3.3.3",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "b337726451f5d530df338fc7f68dee8781b49779"
+                "reference": "0ea965320cec355dba75031c1b23d4c78362e3ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/b337726451f5d530df338fc7f68dee8781b49779",
-                "reference": "b337726451f5d530df338fc7f68dee8781b49779",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/0ea965320cec355dba75031c1b23d4c78362e3ff",
+                "reference": "0ea965320cec355dba75031c1b23d4c78362e3ff",
                 "shasum": ""
             },
             "require": {
@@ -1792,12 +1795,11 @@
             "require-dev": {
                 "doctrine/coding-standard": "^12",
                 "doctrine/common": "^3.0",
-                "phpstan/phpstan": "1.11.1",
+                "phpstan/phpstan": "1.12.7",
                 "phpstan/phpstan-phpunit": "^1",
                 "phpstan/phpstan-strict-rules": "^1.1",
-                "phpunit/phpunit": "^8.5 || ^9.5",
-                "symfony/cache": "^4.4 || ^5.4 || ^6.0",
-                "vimeo/psalm": "4.30.0 || 5.24.0"
+                "phpunit/phpunit": "^8.5.38 || ^9.5",
+                "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0"
             },
             "type": "library",
             "autoload": {
@@ -1846,7 +1848,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/persistence/issues",
-                "source": "https://github.com/doctrine/persistence/tree/3.3.3"
+                "source": "https://github.com/doctrine/persistence/tree/3.4.0"
             },
             "funding": [
                 {
@@ -1862,7 +1864,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-20T10:14:30+00:00"
+            "time": "2024-10-30T19:48:12+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -2140,42 +2142,42 @@
         },
         {
             "name": "laminas/laminas-hydrator",
-            "version": "4.15.0",
+            "version": "4.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-hydrator.git",
-                "reference": "43ccca88313fdcceca37865109dffc69ecd2cf8f"
+                "reference": "a162bd571924968d67ef1f43aed044b8f9c108ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-hydrator/zipball/43ccca88313fdcceca37865109dffc69ecd2cf8f",
-                "reference": "43ccca88313fdcceca37865109dffc69ecd2cf8f",
+                "url": "https://api.github.com/repos/laminas/laminas-hydrator/zipball/a162bd571924968d67ef1f43aed044b8f9c108ef",
+                "reference": "a162bd571924968d67ef1f43aed044b8f9c108ef",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-stdlib": "^3.3",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-                "webmozart/assert": "^1.10"
+                "laminas/laminas-stdlib": "^3.20",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "webmozart/assert": "^1.11"
             },
             "conflict": {
                 "laminas/laminas-servicemanager": "<3.14.0",
                 "zendframework/zend-hydrator": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-eventmanager": "^3.12",
-                "laminas/laminas-modulemanager": "^2.15.0",
+                "laminas/laminas-coding-standard": "~3.0",
+                "laminas/laminas-eventmanager": "^3.13.1",
+                "laminas/laminas-modulemanager": "^2.16.0",
                 "laminas/laminas-serializer": "^2.17.0",
-                "laminas/laminas-servicemanager": "^3.22.1",
-                "phpbench/phpbench": "^1.2.14",
-                "phpunit/phpunit": "^10.4.2",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.15"
+                "laminas/laminas-servicemanager": "^3.23.0",
+                "phpbench/phpbench": "^1.3.1",
+                "phpunit/phpunit": "^10.5.38",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
             },
             "suggest": {
-                "laminas/laminas-eventmanager": "^3.2, to support aggregate hydrator usage",
-                "laminas/laminas-serializer": "^2.9, to use the SerializableStrategy",
-                "laminas/laminas-servicemanager": "^3.14, to support hydrator plugin manager usage"
+                "laminas/laminas-eventmanager": "^3.13, to support aggregate hydrator usage",
+                "laminas/laminas-serializer": "^2.17, to use the SerializableStrategy",
+                "laminas/laminas-servicemanager": "^3.22, to support hydrator plugin manager usage"
             },
             "type": "library",
             "extra": {
@@ -2213,41 +2215,41 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-11-08T11:11:45+00:00"
+            "time": "2024-11-13T14:04:02+00:00"
         },
         {
             "name": "laminas/laminas-paginator",
-            "version": "2.18.1",
+            "version": "2.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-paginator.git",
-                "reference": "6a03499a899fb8ba650594ddf4b4338d4235252a"
+                "reference": "d6339e7ad61491fd76b1490cf9f723d0348ce430"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-paginator/zipball/6a03499a899fb8ba650594ddf4b4338d4235252a",
-                "reference": "6a03499a899fb8ba650594ddf4b4338d4235252a",
+                "url": "https://api.github.com/repos/laminas/laminas-paginator/zipball/d6339e7ad61491fd76b1490cf9f723d0348ce430",
+                "reference": "d6339e7ad61491fd76b1490cf9f723d0348ce430",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "laminas/laminas-stdlib": "^3.10.1",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "conflict": {
                 "zendframework/zend-paginator": "*"
             },
             "require-dev": {
-                "laminas/laminas-cache": "^3.9",
-                "laminas/laminas-cache-storage-adapter-memory": "^2.2.0",
-                "laminas/laminas-coding-standard": "^2.4.0",
-                "laminas/laminas-config": "^3.8.0",
-                "laminas/laminas-filter": "^2.30",
-                "laminas/laminas-servicemanager": "^3.22",
-                "laminas/laminas-view": "^2.25",
-                "phpunit/phpunit": "^9.5.27",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.4"
+                "laminas/laminas-cache": "^3.12.2",
+                "laminas/laminas-cache-storage-adapter-memory": "^2.3.0",
+                "laminas/laminas-coding-standard": "^2.5.0",
+                "laminas/laminas-config": "^3.9.0",
+                "laminas/laminas-filter": "^2.37",
+                "laminas/laminas-servicemanager": "^3.22.1",
+                "laminas/laminas-view": "^2.35",
+                "phpunit/phpunit": "^10.5.30",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.25"
             },
             "suggest": {
                 "laminas/laminas-cache": "Laminas\\Cache component to support cache features",
@@ -2292,34 +2294,34 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-01-11T11:00:36+00:00"
+            "time": "2024-10-16T13:10:19+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.19.0",
+            "version": "3.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "6a192dd0882b514e45506f533b833b623b78fff3"
+                "reference": "8974a1213be42c3e2f70b2c27b17f910291ab2f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/6a192dd0882b514e45506f533b833b623b78fff3",
-                "reference": "6a192dd0882b514e45506f533b833b623b78fff3",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/8974a1213be42c3e2f70b2c27b17f910291ab2f4",
+                "reference": "8974a1213be42c3e2f70b2c27b17f910291ab2f4",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.5",
-                "phpbench/phpbench": "^1.2.15",
-                "phpunit/phpunit": "^10.5.8",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.20.0"
+                "laminas/laminas-coding-standard": "^3.0",
+                "phpbench/phpbench": "^1.3.1",
+                "phpunit/phpunit": "^10.5.38",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
             },
             "type": "library",
             "autoload": {
@@ -2351,39 +2353,42 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-01-19T12:39:49+00:00"
+            "time": "2024-10-29T13:46:07+00:00"
         },
         {
             "name": "mezzio/mezzio-helpers",
-            "version": "5.16.0",
+            "version": "5.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio-helpers.git",
-                "reference": "39ede1ba9ac6398d535339c1fbabcd6e40a55110"
+                "reference": "8d76502e4d71aff178f2084eadd71d12fe737d3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-helpers/zipball/39ede1ba9ac6398d535339c1fbabcd6e40a55110",
-                "reference": "39ede1ba9ac6398d535339c1fbabcd6e40a55110",
+                "url": "https://api.github.com/repos/mezzio/mezzio-helpers/zipball/8d76502e4d71aff178f2084eadd71d12fe737d3c",
+                "reference": "8d76502e4d71aff178f2084eadd71d12fe737d3c",
                 "shasum": ""
             },
             "require": {
-                "mezzio/mezzio-router": "^3.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "mezzio/mezzio-router": "^3.0 || ^4.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
                 "psr/container": "^1.0 || ^2.0",
                 "psr/http-message": "^1.0.1 || ^2.0.0",
                 "psr/http-server-middleware": "^1.0"
             },
             "conflict": {
+                "amphp/amp": "<2.6.4",
+                "amphp/dns": "<2.1.2",
+                "amphp/socket": "<2.3.1",
                 "zendframework/zend-expressive-helpers": "*"
             },
             "require-dev": {
                 "ext-json": "*",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-diactoros": "^3.3",
-                "phpunit/phpunit": "^10.4.2",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.15"
+                "laminas/laminas-coding-standard": "~3.0.1",
+                "laminas/laminas-diactoros": "^3.5",
+                "phpunit/phpunit": "^10.5.45",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.10.1"
             },
             "suggest": {
                 "ext-json": "If you wish to use the JsonStrategy with BodyParamsMiddleware"
@@ -2427,25 +2432,25 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-11-01T11:19:55+00:00"
+            "time": "2025-04-27T08:59:18+00:00"
         },
         {
             "name": "mezzio/mezzio-router",
-            "version": "3.17.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio-router.git",
-                "reference": "78573e16144a70ccf02039e1a2600788119c0dbb"
+                "reference": "851fb024aa9ebd9690450f838d63e0368d188aa7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-router/zipball/78573e16144a70ccf02039e1a2600788119c0dbb",
-                "reference": "78573e16144a70ccf02039e1a2600788119c0dbb",
+                "url": "https://api.github.com/repos/mezzio/mezzio-router/zipball/851fb024aa9ebd9690450f838d63e0368d188aa7",
+                "reference": "851fb024aa9ebd9690450f838d63e0368d188aa7",
                 "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1.5",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
                 "psr/container": "^1.1.2 || ^2.0",
                 "psr/http-factory": "^1.0.2",
                 "psr/http-message": "^1.0.1 || ^2.0.0",
@@ -2457,16 +2462,15 @@
                 "zendframework/zend-expressive-router": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-diactoros": "^3.3.0",
-                "laminas/laminas-servicemanager": "^3.22.1",
-                "laminas/laminas-stratigility": "^3.11.0",
-                "phpunit/phpunit": "^10.4.2",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.15"
+                "laminas/laminas-coding-standard": "~3.0.1",
+                "laminas/laminas-diactoros": "^3.5.0",
+                "laminas/laminas-servicemanager": "^4.4.0",
+                "laminas/laminas-stratigility": "^4.1.0",
+                "phpunit/phpunit": "^10.5.45",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.10.1"
             },
             "suggest": {
-                "mezzio/mezzio-aurarouter": "^3.0 to use the Aura.Router routing adapter",
                 "mezzio/mezzio-fastroute": "^3.0 to use the FastRoute routing adapter",
                 "mezzio/mezzio-laminasrouter": "^3.0 to use the laminas-router routing adapter"
             },
@@ -2509,20 +2513,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-10-31T17:23:17+00:00"
+            "time": "2025-04-27T09:36:28+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.0",
+            "version": "1.13.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
+                "reference": "faed855a7b5f4d4637717c2b3863e277116beb36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/faed855a7b5f4d4637717c2b3863e277116beb36",
+                "reference": "faed855a7b5f4d4637717c2b3863e277116beb36",
                 "shasum": ""
             },
             "require": {
@@ -2561,7 +2565,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.3"
             },
             "funding": [
                 {
@@ -2569,7 +2573,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-12T14:39:25+00:00"
+            "time": "2025-07-05T12:25:42+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -2963,28 +2967,29 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.19.0",
+            "version": "v1.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "67a759e7d8746d501c41536ba40cd9c0a07d6a87"
+                "reference": "35f1adb388946d92e6edab2aa2cb2b60e132ebd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/67a759e7d8746d501c41536ba40cd9c0a07d6a87",
-                "reference": "67a759e7d8746d501c41536ba40cd9c0a07d6a87",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/35f1adb388946d92e6edab2aa2cb2b60e132ebd5",
+                "reference": "35f1adb388946d92e6edab2aa2cb2b60e132ebd5",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2 || ^2.0",
-                "php": "^7.2 || 8.0.* || 8.1.* || 8.2.* || 8.3.*",
+                "php": "^7.4 || 8.0.* || 8.1.* || 8.2.* || 8.3.* || 8.4.*",
                 "phpdocumentor/reflection-docblock": "^5.2",
-                "sebastian/comparator": "^3.0 || ^4.0 || ^5.0 || ^6.0",
-                "sebastian/recursion-context": "^3.0 || ^4.0 || ^5.0 || ^6.0"
+                "sebastian/comparator": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.40",
                 "phpspec/phpspec": "^6.0 || ^7.0",
-                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan": "^2.1.13",
                 "phpunit/phpunit": "^8.0 || ^9.0 || ^10.0"
             },
             "type": "library",
@@ -3026,28 +3031,31 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.19.0"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.22.0"
             },
-            "time": "2024-02-29T11:52:51+00:00"
+            "time": "2025-04-29T14:58:06+00:00"
         },
         {
             "name": "phpspec/prophecy-phpunit",
-            "version": "v2.2.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy-phpunit.git",
-                "reference": "16e1247e139434bce0bac09848bc5c8d882940fc"
+                "reference": "d3c28041d9390c9bca325a08c5b2993ac855bded"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/16e1247e139434bce0bac09848bc5c8d882940fc",
-                "reference": "16e1247e139434bce0bac09848bc5c8d882940fc",
+                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/d3c28041d9390c9bca325a08c5b2993ac855bded",
+                "reference": "d3c28041d9390c9bca325a08c5b2993ac855bded",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3 || ^8",
                 "phpspec/prophecy": "^1.18",
-                "phpunit/phpunit": "^9.1 || ^10.1 || ^11.0"
+                "phpunit/phpunit": "^9.1 || ^10.1 || ^11.0 || ^12.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.10"
             },
             "type": "library",
             "extra": {
@@ -3078,9 +3086,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy-phpunit/issues",
-                "source": "https://github.com/phpspec/prophecy-phpunit/tree/v2.2.0"
+                "source": "https://github.com/phpspec/prophecy-phpunit/tree/v2.4.0"
             },
-            "time": "2024-03-01T08:33:58+00:00"
+            "time": "2025-05-13T13:52:32+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -3125,6 +3133,64 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/1.5.1"
             },
             "time": "2022-05-05T11:32:40+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.21",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "1ccf445757458c06a04eb3f803603cb118fe5fa6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1ccf445757458c06a04eb3f803603cb118fe5fa6",
+                "reference": "1ccf445757458c06a04eb3f803603cb118fe5fa6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-28T19:35:08+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3447,16 +3513,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.21",
+            "version": "9.6.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa"
+                "reference": "43d2cb18d0675c38bd44982a5d1d88f6d53d8d95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
-                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/43d2cb18d0675c38bd44982a5d1d88f6d53d8d95",
+                "reference": "43d2cb18d0675c38bd44982a5d1d88f6d53d8d95",
                 "shasum": ""
             },
             "require": {
@@ -3467,7 +3533,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.12.0",
+                "myclabs/deep-copy": "^1.13.1",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
@@ -3530,7 +3596,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.21"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.23"
             },
             "funding": [
                 {
@@ -3542,11 +3608,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-19T10:50:18+00:00"
+            "time": "2025-05-02T06:40:34+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3819,6 +3893,66 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "40a71441dd73fa150a66102f5ca1364c44fc8fff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/40a71441dd73fa150a66102f5ca1364c44fc8fff",
+                "reference": "40a71441dd73fa150a66102f5ca1364c44fc8fff",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.1.18"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-17T19:30:06+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4846,16 +4980,16 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "3.3.0",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "f56b220fe2db1ade4c88098d83413ebdfc3bf876"
+                "reference": "7dcfc67d60b0272926dabad1ec01f6b8a5fb5e67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/f56b220fe2db1ade4c88098d83413ebdfc3bf876",
-                "reference": "f56b220fe2db1ade4c88098d83413ebdfc3bf876",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/7dcfc67d60b0272926dabad1ec01f6b8a5fb5e67",
+                "reference": "7dcfc67d60b0272926dabad1ec01f6b8a5fb5e67",
                 "shasum": ""
             },
             "require": {
@@ -4898,7 +5032,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/3.3.0"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.4.0"
             },
             "funding": [
                 {
@@ -4910,20 +5044,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-05-01T10:20:27+00:00"
+            "time": "2024-12-16T12:45:15+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.10.3",
+            "version": "3.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "62d32998e820bddc40f99f8251958aed187a5c9c"
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/62d32998e820bddc40f99f8251958aed187a5c9c",
-                "reference": "62d32998e820bddc40f99f8251958aed187a5c9c",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5b5e3821314f947dd040c70f7992a64eac89025c",
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c",
                 "shasum": ""
             },
             "require": {
@@ -4988,22 +5122,26 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-09-18T10:38:58+00:00"
+            "time": "2025-06-17T22:17:01+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.12",
+            "version": "v6.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "72d080eb9edf80e36c19be61f72c98ed8273b765"
+                "reference": "59266a5bf6a596e3e0844fd95e6ad7ea3c1d3350"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/72d080eb9edf80e36c19be61f72c98ed8273b765",
-                "reference": "72d080eb9edf80e36c19be61f72c98ed8273b765",
+                "url": "https://api.github.com/repos/symfony/console/zipball/59266a5bf6a596e3e0844fd95e6ad7ea3c1d3350",
+                "reference": "59266a5bf6a596e3e0844fd95e6ad7ea3c1d3350",
                 "shasum": ""
             },
             "require": {
@@ -5068,7 +5206,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.12"
+                "source": "https://github.com/symfony/console/tree/v6.4.24"
             },
             "funding": [
                 {
@@ -5080,24 +5218,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-20T08:15:52+00:00"
+            "time": "2025-07-30T10:38:54+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.5.0",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1"
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
-                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
                 "shasum": ""
             },
             "require": {
@@ -5105,12 +5247,12 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "3.5-dev"
-                },
                 "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -5135,7 +5277,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -5151,20 +5293,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:32:20+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.4.12",
+            "version": "v6.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "f810e3cbdf7fdc35983968523d09f349fa9ada12"
+                "reference": "75ae2edb7cdcc0c53766c30b0a2512b8df574bd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/f810e3cbdf7fdc35983968523d09f349fa9ada12",
-                "reference": "f810e3cbdf7fdc35983968523d09f349fa9ada12",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/75ae2edb7cdcc0c53766c30b0a2512b8df574bd8",
+                "reference": "75ae2edb7cdcc0c53766c30b0a2512b8df574bd8",
                 "shasum": ""
             },
             "require": {
@@ -5201,7 +5343,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.4.12"
+                "source": "https://github.com/symfony/filesystem/tree/v6.4.24"
             },
             "funding": [
                 {
@@ -5213,15 +5355,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-16T16:01:33+00:00"
+            "time": "2025-07-10T08:14:14+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -5245,8 +5391,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -5280,7 +5426,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -5300,7 +5446,7 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
@@ -5321,8 +5467,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -5358,7 +5504,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -5378,7 +5524,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -5399,8 +5545,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -5439,7 +5585,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -5459,19 +5605,20 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
                 "shasum": ""
             },
             "require": {
+                "ext-iconv": "*",
                 "php": ">=7.2"
             },
             "provide": {
@@ -5483,8 +5630,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -5519,7 +5666,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -5535,7 +5682,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2024-12-23T08:48:59+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
@@ -5557,8 +5704,8 @@
             "type": "metapackage",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -5604,16 +5751,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
                 "shasum": ""
             },
             "require": {
@@ -5622,8 +5769,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -5664,7 +5811,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -5680,20 +5827,96 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2025-01-02T08:10:11+00:00"
         },
         {
-            "name": "symfony/service-contracts",
-            "version": "v3.5.0",
+            "name": "symfony/polyfill-php84",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f"
+                "url": "https://github.com/symfony/polyfill-php84.git",
+                "reference": "000df7860439609837bbe28670b0be15783b7fbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
-                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/000df7860439609837bbe28670b0be15783b7fbf",
+                "reference": "000df7860439609837bbe28670b0be15783b7fbf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php84\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.32.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-02-20T12:04:08+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
+                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
                 "shasum": ""
             },
             "require": {
@@ -5706,12 +5929,12 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "3.5-dev"
-                },
                 "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -5747,7 +5970,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.5.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -5763,20 +5986,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:32:20+00:00"
+            "time": "2025-04-25T09:37:31+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.12",
+            "version": "v6.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b"
+                "reference": "f0ce0bd36a3accb4a225435be077b4b4875587f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f8a1ccebd0997e16112dfecfd74220b78e5b284b",
-                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/f0ce0bd36a3accb4a225435be077b4b4875587f4",
+                "reference": "f0ce0bd36a3accb4a225435be077b4b4875587f4",
                 "shasum": ""
             },
             "require": {
@@ -5833,7 +6056,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.12"
+                "source": "https://github.com/symfony/string/tree/v6.4.24"
             },
             "funding": [
                 {
@@ -5845,11 +6068,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-20T08:15:52+00:00"
+            "time": "2025-07-10T08:14:14+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5976,11 +6203,11 @@
             "type": "project",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.x-dev",
-                    "dev-4.x": "4.x-dev",
-                    "dev-3.x": "3.x-dev",
+                    "dev-1.x": "1.x-dev",
                     "dev-2.x": "2.x-dev",
-                    "dev-1.x": "1.x-dev"
+                    "dev-3.x": "3.x-dev",
+                    "dev-4.x": "4.x-dev",
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -6013,21 +6240,21 @@
         },
         {
             "name": "webimpress/coding-standard",
-            "version": "1.3.2",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/coding-standard.git",
-                "reference": "710f71ac95d36d931e76b47132b599c39abfab11"
+                "reference": "6f6a1a90bd9e18fc8bee0660dd1d1ce68cf9fc53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/710f71ac95d36d931e76b47132b599c39abfab11",
-                "reference": "710f71ac95d36d931e76b47132b599c39abfab11",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/6f6a1a90bd9e18fc8bee0660dd1d1ce68cf9fc53",
+                "reference": "6f6a1a90bd9e18fc8bee0660dd1d1ce68cf9fc53",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3 || ^8.0",
-                "squizlabs/php_codesniffer": "^3.7.2"
+                "squizlabs/php_codesniffer": "^3.10.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.6.15"
@@ -6056,7 +6283,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webimpress/coding-standard/issues",
-                "source": "https://github.com/webimpress/coding-standard/tree/1.3.2"
+                "source": "https://github.com/webimpress/coding-standard/tree/1.4.0"
             },
             "funding": [
                 {
@@ -6064,12 +6291,12 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-18T07:25:41+00:00"
+            "time": "2024-10-16T06:55:17+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -6077,7 +6304,7 @@
         "ext-dom": "*",
         "ext-json": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1.99"
     },

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,6 +14,7 @@
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
+    <file>rector.php</file>
 
     <!-- Include all rules from the Laminas Coding Standard -->
     <rule ref="LaminasCodingStandard"/>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -15,9 +15,6 @@
       <code><![CDATA[$resource]]></code>
       <code><![CDATA[$value]]></code>
     </MissingClosureParamType>
-    <MissingClosureReturnType>
-      <code><![CDATA[function ($item) {]]></code>
-    </MissingClosureReturnType>
     <MixedArgument>
       <code><![CDATA[$links]]></code>
       <code><![CDATA[$links]]></code>
@@ -65,9 +62,6 @@
     </MixedReturnTypeCoercion>
   </file>
   <file src="src/HalResponseFactory.php">
-    <MixedArgument>
-      <code><![CDATA[$matchedType->getValue()]]></code>
-    </MixedArgument>
     <UndefinedInterfaceMethod>
       <code><![CDATA[getValue]]></code>
     </UndefinedInterfaceMethod>
@@ -89,25 +83,10 @@
     <InvalidCast>
       <code><![CDATA[$uri]]></code>
     </InvalidCast>
-    <MixedArgument>
-      <code><![CDATA[is_object($rel) ? $rel::class : gettype($rel)]]></code>
-    </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[string|string[]]]></code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[is_string($relation) ? [$relation] : $relation]]></code>
-      <code><![CDATA[is_string($relation) ? [$relation] : $relation]]></code>
-    </MixedReturnStatement>
-    <PossiblyInvalidPropertyAssignmentValue>
-      <code><![CDATA[$this->validateRelation($relation)]]></code>
-    </PossiblyInvalidPropertyAssignmentValue>
     <RedundantCondition>
-      <code><![CDATA[gettype($rel)]]></code>
-      <code><![CDATA[is_object($href)]]></code>
       <code><![CDATA[is_string($uri)]]></code>
     </RedundantCondition>
     <TypeDoesNotContainType>
@@ -118,9 +97,7 @@
       <code><![CDATA[! is_string($rel) || empty($rel)]]></code>
       <code><![CDATA[! is_string($rel) || empty($rel)]]></code>
       <code><![CDATA[(string) $uri]]></code>
-      <code><![CDATA[gettype($href)]]></code>
       <code><![CDATA[is_object($href)]]></code>
-      <code><![CDATA[is_object($rel)]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/LinkCollection.php">
@@ -128,9 +105,6 @@
       <code><![CDATA[self]]></code>
       <code><![CDATA[self]]></code>
     </LessSpecificImplementedReturnType>
-    <MissingParamType>
-      <code><![CDATA[$rel]]></code>
-    </MissingParamType>
   </file>
   <file src="src/LinkGenerator/MezzioUrlGenerator.php">
     <ArgumentTypeCoercion>
@@ -349,18 +323,6 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="src/ResourceGenerator/ExtractCollectionTrait.php">
-    <MethodSignatureMismatch>
-      <code><![CDATA[abstract protected function generateSelfLink(
-        AbstractCollectionMetadata $metadata,
-        ResourceGeneratorInterface $resourceGenerator,
-        ServerRequestInterface $request
-    ): Link;]]></code>
-      <code><![CDATA[abstract protected function generateSelfLink(
-        AbstractCollectionMetadata $metadata,
-        ResourceGeneratorInterface $resourceGenerator,
-        ServerRequestInterface $request
-    ): Link;]]></code>
-    </MethodSignatureMismatch>
     <MixedArgument>
       <code><![CDATA[$item]]></code>
       <code><![CDATA[$item]]></code>
@@ -398,9 +360,6 @@
     </UndefinedMethod>
   </file>
   <file src="src/ResourceGenerator/RouteBasedCollectionStrategy.php">
-    <MethodSignatureMismatch>
-      <code><![CDATA[protected function generateSelfLink(]]></code>
-    </MethodSignatureMismatch>
     <MixedArgument>
       <code><![CDATA[$metadata->getQueryStringArguments()]]></code>
       <code><![CDATA[$metadata->getQueryStringArguments()]]></code>
@@ -437,9 +396,6 @@
     </MixedArrayOffset>
   </file>
   <file src="src/ResourceGenerator/UrlBasedCollectionStrategy.php">
-    <MethodSignatureMismatch>
-      <code><![CDATA[protected function generateSelfLink(]]></code>
-    </MethodSignatureMismatch>
     <MixedArgument>
       <code><![CDATA[$url]]></code>
     </MixedArgument>
@@ -492,9 +448,6 @@
     <MoreSpecificReturnType>
       <code><![CDATA[Link]]></code>
     </MoreSpecificReturnType>
-    <RedundantCondition>
-      <code><![CDATA[assertIsArray]]></code>
-    </RedundantCondition>
   </file>
   <file src="test/ConfigProviderTest.php">
     <RedundantCondition>
@@ -579,21 +532,10 @@
     </UndefinedClass>
   </file>
   <file src="test/LinkTest.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$uri]]></code>
-    </ArgumentTypeCoercion>
     <MixedArgument>
-      <code><![CDATA[$name]]></code>
-      <code><![CDATA[$name]]></code>
-      <code><![CDATA[$rel]]></code>
-      <code><![CDATA[$rel]]></code>
-      <code><![CDATA[$uri]]></code>
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
     </MixedArgument>
-    <TooFewArguments>
-      <code><![CDATA[new Link()]]></code>
-    </TooFewArguments>
   </file>
   <file src="test/PHPUnitDeprecatedAssertions.php">
     <ArgumentTypeCoercion>
@@ -809,18 +751,6 @@
       <code><![CDATA[$request]]></code>
       <code><![CDATA[$request]]></code>
       <code><![CDATA[$request]]></code>
-      <code><![CDATA[Argument::that(function (array $params) use ($i) {
-                        return array_key_exists('foo_id', $params)
-                            && array_key_exists('bar_id', $params)
-                            && $params['foo_id'] === 1234
-                            && $params['bar_id'] === $i;
-                    })]]></code>
-      <code><![CDATA[Argument::that(function (array $params) use ($page) {
-                return array_key_exists('foo_id', $params)
-                    && array_key_exists('p', $params)
-                    && $params['foo_id'] === 1234
-                    && $params['p'] === $page;
-            })]]></code>
     </InvalidArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$request->reveal()]]></code>
@@ -839,12 +769,6 @@
     <InvalidArgument>
       <code><![CDATA[$linkGenerator]]></code>
       <code><![CDATA[$request]]></code>
-      <code><![CDATA[Argument::that(function (array $params) use ($i) {
-                        return array_key_exists('foo_id', $params)
-                            && array_key_exists('bar_id', $params)
-                            && $params['foo_id'] === 1234
-                            && $params['bar_id'] === $i;
-                    })]]></code>
     </InvalidArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$request->reveal()]]></code>
@@ -901,24 +825,6 @@
       <code><![CDATA[assertInternalType]]></code>
     </DeprecatedMethod>
     <InvalidArgument>
-      <code><![CDATA[Argument::that(function (array $params) use ($i) {
-                        return array_key_exists('foo_bar_id', $params)
-                            && array_key_exists('test', $params)
-                            && $params['foo_bar_id'] === $i
-                            && $params['test'] === 'param';
-                    })]]></code>
-      <code><![CDATA[Argument::that(function (array $params) use ($i) {
-                        return array_key_exists('foo_bar_id', $params)
-                            && array_key_exists('test', $params)
-                            && $params['foo_bar_id'] === $i
-                            && $params['test'] === 'param';
-                    })]]></code>
-      <code><![CDATA[Argument::that(function (array $params) {
-                    return array_key_exists('foo_bar_id', $params)
-                        && array_key_exists('test', $params)
-                        && $params['foo_bar_id'] === 'XXXX-YYYY-ZZZZ'
-                        && $params['test'] === 'param';
-                })]]></code>
       <code><![CDATA[Argument::type('array')]]></code>
       <code><![CDATA[Argument::type('array')]]></code>
       <code><![CDATA[Argument::type('array')]]></code>

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPhpSets(php81: true)
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/test',
+    ])
+    ->withPreparedSets(
+        typeDeclarations: true,
+    );

--- a/src/Exception/InvalidResourceValueException.php
+++ b/src/Exception/InvalidResourceValueException.php
@@ -7,28 +7,21 @@ namespace Mezzio\Hal\Exception;
 use Mezzio\Hal\HalResource;
 use RuntimeException;
 
-use function gettype;
-use function is_object;
+use function get_debug_type;
 use function sprintf;
 
 class InvalidResourceValueException extends RuntimeException implements ExceptionInterface
 {
-    /**
-     * @param mixed $value
-     */
-    public static function fromValue($value): self
+    public static function fromValue(mixed $value): self
     {
         return new self(sprintf(
             'Encountered non-primitive type "%s" when serializing %s instance; unable to serialize',
-            is_object($value) ? $value::class : gettype($value),
+            get_debug_type($value),
             HalResource::class
         ));
     }
 
-    /**
-     * @param object $object
-     */
-    public static function fromObject($object): self
+    public static function fromObject(object $object): self
     {
         return new self(sprintf(
             'Encountered object of type "%s" when serializing %s instance; unable to serialize',

--- a/src/Exception/InvalidStrategyException.php
+++ b/src/Exception/InvalidStrategyException.php
@@ -7,8 +7,7 @@ namespace Mezzio\Hal\Exception;
 use InvalidArgumentException;
 use Mezzio\Hal\ResourceGenerator\StrategyInterface;
 
-use function gettype;
-use function is_object;
+use function get_debug_type;
 use function sprintf;
 
 class InvalidStrategyException extends InvalidArgumentException implements ExceptionInterface
@@ -22,14 +21,11 @@ class InvalidStrategyException extends InvalidArgumentException implements Excep
         ));
     }
 
-    /**
-     * @param mixed $strategy
-     */
-    public static function forInstance($strategy): self
+    public static function forInstance(mixed $strategy): self
     {
         return new self(sprintf(
             'Invalid strategy of type "%s"; does not implement %s',
-            is_object($strategy) ? $strategy::class : gettype($strategy),
+            get_debug_type($strategy),
             StrategyInterface::class
         ));
     }

--- a/src/HalResource.php
+++ b/src/HalResource.php
@@ -36,10 +36,10 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
     use LinkCollection;
 
     /** @var array All data to represent. */
-    private $data = [];
+    private array $data = [];
 
     /** @var array<array-key, self|array<array-key, self>> */
-    private $embedded = [];
+    private array $embedded = [];
 
     /**
      * @param array $data
@@ -56,7 +56,7 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
 
         $context = self::class;
 
-        array_walk($data, function ($value, $name) use ($context) {
+        array_walk($data, function ($value, $name) use ($context): void {
             $this->validateElementName($name, $context);
 
             if ($value instanceof self || $this->isResourceCollection($value)) {
@@ -67,7 +67,7 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
             $this->data[$name] = $value;
         });
 
-        array_walk($embedded, function ($resource, $name) use ($context) {
+        array_walk($embedded, function ($resource, $name) use ($context): void {
             $this->validateElementName($name, $context);
             $this->detectCollisionWithData($name, $context);
 
@@ -89,9 +89,12 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
         });
 
         if (
-            array_reduce($links, function ($containsNonLinkItem, $link) {
-                return $containsNonLinkItem || ! $link instanceof LinkInterface;
-            }, false)
+            array_reduce(
+                $links,
+                fn($containsNonLinkItem, $link): bool =>
+                $containsNonLinkItem || ! $link instanceof LinkInterface,
+                false
+            )
         ) {
             throw new InvalidArgumentException('Non-Link item provided in $links array');
         }
@@ -118,11 +121,7 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
             return null;
         }
 
-        if (isset($this->embedded[$name])) {
-            return $this->embedded[$name];
-        }
-
-        return $this->data[$name];
+        return $this->embedded[$name] ?? $this->data[$name];
     }
 
     /**
@@ -323,9 +322,12 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
         // $resource is an collection; existing individual or collection resource exists
         if (
             is_array($resource)
-            && array_reduce($resource, function (bool $allAreResources, $resource): bool {
-                return $allAreResources && $resource instanceof HalResource;
-            }, true)
+            && array_reduce(
+                $resource,
+                fn(bool $allAreResources, $resource): bool =>
+                $allAreResources && $resource instanceof HalResource,
+                true
+            )
         ) {
             return $this->aggregateEmbeddedCollection($name, $resource, $context);
         }
@@ -411,14 +413,12 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
             return $this->embedEmptyCollections;
         }
 
-        return array_reduce($value, static function ($isResource, $item) {
-            return $isResource && $item instanceof self;
-        }, true);
+        return array_reduce($value, static fn($isResource, $item): bool => $isResource && $item instanceof self, true);
     }
 
     private function serializeLinks(): array
     {
-        $relations = array_reduce($this->links, function (array $byRelation, LinkInterface $link) {
+        $relations = array_reduce($this->links, function (array $byRelation, LinkInterface $link): array {
             $representation = array_merge($link->getAttributes(), [
                 'href' => $link->getHref(),
             ]);
@@ -427,7 +427,7 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
             }
 
             $linkRels = $link->getRels();
-            array_walk($linkRels, function ($rel) use (&$byRelation, $representation) {
+            array_walk($linkRels, function ($rel) use (&$byRelation, $representation): void {
                 $forceCollection = array_key_exists(Link::AS_COLLECTION, $representation)
                     && $representation[Link::AS_COLLECTION];
                 unset($representation[Link::AS_COLLECTION]);
@@ -458,7 +458,7 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
             return $byRelation;
         }, []);
 
-        array_walk($relations, function ($links, $key) use (&$relations) {
+        array_walk($relations, function ($links, $key) use (&$relations): void {
             if (isset($relations[$key][Link::AS_COLLECTION])) {
                 // If forcing a collection, do nothing to the links, but DO
                 // remove the marker indicating a collection should be
@@ -484,9 +484,7 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
             function ($resource, string $name) use (&$embedded): void {
                 $embedded[$name] = $resource instanceof self
                     ? $resource->toArray()
-                    : array_map(function ($item) {
-                        return $item->toArray();
-                    }, $resource);
+                    : array_map(fn($item): mixed => $item->toArray(), $resource);
             }
         );
 

--- a/src/HalResponseFactory.php
+++ b/src/HalResponseFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Mezzio\Hal;
 
+use Mezzio\Hal\Renderer\JsonRenderer;
+use Mezzio\Hal\Renderer\XmlRenderer;
 use Mezzio\Hal\Response\CallableResponseFactoryDecorator;
 use Negotiation\Negotiator;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -11,7 +13,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 use function is_callable;
-use function strstr;
+use function str_contains;
 
 class HalResponseFactory
 {
@@ -30,18 +32,14 @@ class HalResponseFactory
         'application/*+xml',
     ];
 
-    /** @var Renderer\JsonRenderer */
-    private $jsonRenderer;
+    private readonly JsonRenderer $jsonRenderer;
 
     /**
      * A callable capable of producing an empty ResponseInterface instance.
-     *
-     * @var ResponseFactoryInterface
      */
-    private $responseFactory;
+    private readonly ResponseFactoryInterface $responseFactory;
 
-    /** @var Renderer\XmlRenderer */
-    private $xmlRenderer;
+    private readonly XmlRenderer $xmlRenderer;
 
     /**
      * @param (callable():ResponseInterface)|ResponseFactoryInterface $responseFactory
@@ -54,15 +52,13 @@ class HalResponseFactory
         if (is_callable($responseFactory)) {
             // Ensures type safety of the composed factory
             $responseFactory = new CallableResponseFactoryDecorator(
-                static function () use ($responseFactory): ResponseInterface {
-                    return $responseFactory();
-                }
+                static fn(): ResponseInterface => $responseFactory()
             );
         }
 
         $this->responseFactory = $responseFactory;
-        $this->jsonRenderer    = $jsonRenderer ?: new Renderer\JsonRenderer();
-        $this->xmlRenderer     = $xmlRenderer ?: new Renderer\XmlRenderer();
+        $this->jsonRenderer    = $jsonRenderer ?: new JsonRenderer();
+        $this->xmlRenderer     = $xmlRenderer ?: new XmlRenderer();
     }
 
     public function createResponse(
@@ -74,7 +70,7 @@ class HalResponseFactory
         $matchedType = (new Negotiator())->getBest($accept, self::NEGOTIATION_PRIORITIES);
 
         switch (true) {
-            case $matchedType && strstr($matchedType->getValue(), 'json') !== false:
+            case $matchedType && str_contains((string) $matchedType->getValue(), 'json'):
                 $renderer   = $this->jsonRenderer;
                 $mediaType .= '+json';
                 break;

--- a/src/Link.php
+++ b/src/Link.php
@@ -6,10 +6,11 @@ namespace Mezzio\Hal;
 
 use InvalidArgumentException;
 use Psr\Link\EvolvableLinkInterface;
+use Stringable;
 
 use function array_filter;
 use function array_reduce;
-use function gettype;
+use function get_debug_type;
 use function in_array;
 use function is_array;
 use function is_object;
@@ -22,17 +23,12 @@ class Link implements EvolvableLinkInterface
 {
     public const AS_COLLECTION = '__FORCE_COLLECTION__';
 
-    /** @var array */
-    private $attributes;
+    private array $attributes;
 
     /** @var string[] Link relation types */
-    private $relations;
+    private array $relations;
 
-    /** @var string */
-    private $uri;
-
-    /** @var bool Whether or not the link is templated */
-    private $isTemplated;
+    private string $uri;
 
     /**
      * @param string|string[] $relation One or more relations represented by this link.
@@ -41,18 +37,21 @@ class Link implements EvolvableLinkInterface
      * @throws InvalidArgumentException If an array $relation is provided, but one or
      *     more values is not a string.
      */
-    public function __construct($relation, string $uri = '', bool $isTemplated = false, array $attributes = [])
-    {
-        $this->relations   = $this->validateRelation($relation);
-        $this->uri         = is_string($uri) ? $uri : (string) $uri;
-        $this->isTemplated = $isTemplated;
-        $this->attributes  = $this->validateAttributes($attributes);
+    public function __construct(
+        $relation,
+        string $uri = '', /** @var bool Whether or not the link is templated */
+        private bool $isTemplated = false,
+        array $attributes = []
+    ) {
+        $this->relations  = $this->validateRelation($relation);
+        $this->uri        = is_string($uri) ? $uri : (string) $uri;
+        $this->attributes = $this->validateAttributes($attributes);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getHref()
+    public function getHref(): string
     {
         return $this->uri;
     }
@@ -60,7 +59,7 @@ class Link implements EvolvableLinkInterface
     /**
      * {@inheritDoc}
      */
-    public function isTemplated()
+    public function isTemplated(): bool
     {
         return $this->isTemplated;
     }
@@ -68,7 +67,7 @@ class Link implements EvolvableLinkInterface
     /**
      * {@inheritDoc}
      */
-    public function getRels()
+    public function getRels(): array
     {
         return $this->relations;
     }
@@ -76,7 +75,7 @@ class Link implements EvolvableLinkInterface
     /**
      * {@inheritDoc}
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return $this->attributes;
     }
@@ -87,7 +86,7 @@ class Link implements EvolvableLinkInterface
      * @throws InvalidArgumentException If $href is not a string, and not an
      *     object implementing __toString.
      */
-    public function withHref($href)
+    public function withHref(string|Stringable $href): self
     {
         if (
             ! is_string($href)
@@ -96,7 +95,7 @@ class Link implements EvolvableLinkInterface
             throw new InvalidArgumentException(sprintf(
                 '%s expects a string URI or an object implementing __toString; received %s',
                 __METHOD__,
-                is_object($href) ? $href::class : gettype($href)
+                get_debug_type($href)
             ));
         }
         $new      = clone $this;
@@ -109,13 +108,13 @@ class Link implements EvolvableLinkInterface
      *
      * @throws InvalidArgumentException If $rel is not a string.
      */
-    public function withRel($rel)
+    public function withRel(string $rel): self
     {
         if (! is_string($rel) || empty($rel)) {
             throw new InvalidArgumentException(sprintf(
                 '%s expects a non-empty string relation type; received %s',
                 __METHOD__,
-                is_object($rel) ? $rel::class : gettype($rel)
+                get_debug_type($rel)
             ));
         }
 
@@ -131,7 +130,7 @@ class Link implements EvolvableLinkInterface
     /**
      * {@inheritDoc}
      */
-    public function withoutRel($rel)
+    public function withoutRel(string $rel): self
     {
         if (! is_string($rel) || empty($rel)) {
             return $this;
@@ -142,9 +141,7 @@ class Link implements EvolvableLinkInterface
         }
 
         $new            = clone $this;
-        $new->relations = array_filter($this->relations, function ($value) use ($rel) {
-            return $rel !== $value;
-        });
+        $new->relations = array_filter($this->relations, fn($value): bool => $rel !== $value);
         return $new;
     }
 
@@ -156,7 +153,7 @@ class Link implements EvolvableLinkInterface
      * @throws InvalidArgumentException If $value is an array, but one or more values
      *     is not a string.
      */
-    public function withAttribute($attribute, $value)
+    public function withAttribute(string $attribute, mixed $value): self
     {
         $this->validateAttributeName($attribute, __METHOD__);
         $this->validateAttributeValue($value, __METHOD__);
@@ -169,7 +166,7 @@ class Link implements EvolvableLinkInterface
     /**
      * {@inheritDoc}
      */
-    public function withoutAttribute($attribute)
+    public function withoutAttribute(string $attribute): self
     {
         if (! is_string($attribute) || empty($attribute)) {
             return $this;
@@ -185,40 +182,37 @@ class Link implements EvolvableLinkInterface
     }
 
     /**
-     * @param mixed $name
      * @throws InvalidArgumentException If $attribute is not a string or is empty.
      */
-    private function validateAttributeName($name, string $context): void
+    private function validateAttributeName(mixed $name, string $context): void
     {
         if (! is_string($name) || empty($name)) {
             throw new InvalidArgumentException(sprintf(
                 '%s expects the $name argument to be a non-empty string; received %s',
                 $context,
-                is_object($name) ? $name::class : gettype($name)
+                get_debug_type($name)
             ));
         }
     }
 
     /**
-     * @param mixed $value
      * @throws InvalidArgumentException If $value is neither a scalar nor an array.
      * @throws InvalidArgumentException If $value is an array, but one or more values
      *     is not a string.
      */
-    private function validateAttributeValue($value, string $context): void
+    private function validateAttributeValue(mixed $value, string $context): void
     {
         if (! is_scalar($value) && ! is_array($value)) {
             throw new InvalidArgumentException(sprintf(
                 '%s expects the $value to be a PHP primitive or array of strings; received %s',
                 $context,
-                is_object($value) ? $value::class : gettype($value)
+                get_debug_type($value)
             ));
         }
 
         if (
-            is_array($value) && array_reduce($value, function ($isInvalid, $value) {
-                return $isInvalid || ! is_string($value);
-            }, false)
+            is_array($value)
+            && array_reduce($value, fn($isInvalid, $value): bool => $isInvalid || ! is_string($value), false)
         ) {
             throw new InvalidArgumentException(sprintf(
                 '%s expects $value to contain an array of strings; one or more values was not a string',
@@ -237,24 +231,26 @@ class Link implements EvolvableLinkInterface
     }
 
     /**
-     * @param mixed $relation
-     * @return string|string[]
+     * @return string[]
      * @throws InvalidArgumentException If $relation is neither a string nor an array.
      * @throws InvalidArgumentException If $relation is an array, but any given value in it is not a string.
      */
-    private function validateRelation($relation)
+    private function validateRelation(mixed $relation): array
     {
         if (! is_array($relation) && (! is_string($relation) || empty($relation))) {
             throw new InvalidArgumentException(sprintf(
                 '$relation argument must be a string or array of strings; received %s',
-                is_object($relation) ? $relation::class : gettype($relation)
+                get_debug_type($relation)
             ));
         }
 
         if (
-            is_array($relation) && false === array_reduce($relation, function ($isString, $value) {
-                return $isString === false || is_string($value) || empty($value);
-            }, true)
+            is_array($relation)
+            && false === array_reduce(
+                $relation,
+                fn($isString, $value): bool => $isString === false || is_string($value) || empty($value),
+                true
+            )
         ) {
             throw new InvalidArgumentException(
                 'When passing an array for $relation, each value must be a non-empty string; '
@@ -262,6 +258,9 @@ class Link implements EvolvableLinkInterface
             );
         }
 
-        return is_string($relation) ? [$relation] : $relation;
+        /** @var array<array-key, string> $result */
+        $result = is_string($relation) ? [$relation] : $relation;
+
+        return $result;
     }
 }

--- a/src/LinkCollection.php
+++ b/src/LinkCollection.php
@@ -14,7 +14,7 @@ use function in_array;
 trait LinkCollection
 {
     /** @var LinkInterface[] */
-    private $links = [];
+    private array $links = [];
 
     /**
      * {@inheritDoc}
@@ -33,9 +33,9 @@ trait LinkCollection
      * @return LinkInterface[]
      * @psalm-return array<array-key, LinkInterface>
      */
-    public function getLinksByRel($rel): array
+    public function getLinksByRel(string $rel): array
     {
-        return array_filter($this->links, function (LinkInterface $link) use ($rel) {
+        return array_filter($this->links, function (LinkInterface $link) use ($rel): bool {
             $rels = $link->getRels();
             return in_array($rel, $rels, true);
         });
@@ -65,9 +65,7 @@ trait LinkCollection
         }
 
         $new        = clone $this;
-        $new->links = array_filter($this->links, function (LinkInterface $compare) use ($link) {
-            return $link !== $compare;
-        });
+        $new->links = array_filter($this->links, fn(LinkInterface $compare): bool => $link !== $compare);
         return $new;
     }
 }

--- a/src/LinkGenerator.php
+++ b/src/LinkGenerator.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class LinkGenerator
 {
-    public function __construct(private UrlGeneratorInterface $urlGenerator)
+    public function __construct(private readonly UrlGeneratorInterface $urlGenerator)
     {
     }
 

--- a/src/LinkGenerator/MezzioUrlGenerator.php
+++ b/src/LinkGenerator/MezzioUrlGenerator.php
@@ -10,11 +10,9 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class MezzioUrlGenerator implements UrlGeneratorInterface
 {
-    /** @var null|ServerUrlHelper */
-    private $serverUrlHelper;
+    private readonly ?ServerUrlHelper $serverUrlHelper;
 
-    /** @var UrlHelper */
-    private $urlHelper;
+    private readonly UrlHelper $urlHelper;
 
     public function __construct(UrlHelper $urlHelper, ?ServerUrlHelper $serverUrlHelper = null)
     {

--- a/src/LinkGenerator/MezzioUrlGeneratorFactory.php
+++ b/src/LinkGenerator/MezzioUrlGeneratorFactory.php
@@ -13,9 +13,6 @@ use function sprintf;
 
 class MezzioUrlGeneratorFactory
 {
-    /** @var string */
-    private $urlHelperServiceName;
-
     /**
      * Allow serialization
      */
@@ -29,9 +26,8 @@ class MezzioUrlGeneratorFactory
     /**
      * Vary behavior based on the URL helper service name.
      */
-    public function __construct(string $urlHelperServiceName = UrlHelper::class)
+    public function __construct(private readonly string $urlHelperServiceName = UrlHelper::class)
     {
-        $this->urlHelperServiceName = $urlHelperServiceName;
     }
 
     public function __invoke(ContainerInterface $container): MezzioUrlGenerator

--- a/src/LinkGeneratorFactory.php
+++ b/src/LinkGeneratorFactory.php
@@ -8,9 +8,6 @@ use Psr\Container\ContainerInterface;
 
 class LinkGeneratorFactory
 {
-    /** @var string */
-    private $urlGeneratorServiceName;
-
     /**
      * Allow serialization
      */
@@ -24,9 +21,9 @@ class LinkGeneratorFactory
     /**
      * Allow varying behavior based on URL generator service name.
      */
-    public function __construct(string $urlGeneratorServiceName = LinkGenerator\UrlGeneratorInterface::class)
-    {
-        $this->urlGeneratorServiceName = $urlGeneratorServiceName;
+    public function __construct(
+        private readonly string $urlGeneratorServiceName = LinkGenerator\UrlGeneratorInterface::class
+    ) {
     }
 
     public function __invoke(ContainerInterface $container): LinkGenerator

--- a/src/Metadata/AbstractCollectionMetadata.php
+++ b/src/Metadata/AbstractCollectionMetadata.php
@@ -9,14 +9,11 @@ abstract class AbstractCollectionMetadata extends AbstractMetadata
     public const TYPE_PLACEHOLDER = 'placeholder';
     public const TYPE_QUERY       = 'query';
 
-    /** @var string */
-    protected $collectionRelation;
+    protected string $collectionRelation;
 
-    /** @var string */
-    protected $paginationParam;
+    protected string $paginationParam;
 
-    /** @var string */
-    protected $paginationParamType;
+    protected string $paginationParamType;
 
     public function getCollectionRelation(): string
     {

--- a/src/Metadata/AbstractMetadata.php
+++ b/src/Metadata/AbstractMetadata.php
@@ -10,8 +10,7 @@ abstract class AbstractMetadata
 {
     use LinkCollection;
 
-    /** @var string */
-    protected $class;
+    protected string $class;
 
     public function getClass(): string
     {

--- a/src/Metadata/AbstractResourceMetadata.php
+++ b/src/Metadata/AbstractResourceMetadata.php
@@ -9,13 +9,10 @@ abstract class AbstractResourceMetadata extends AbstractMetadata
     /**
      * Service name of an ExtractionInterface implementation to use when
      * extracting a resource of this type.
-     *
-     * @var string
      */
-    protected $extractor;
+    protected string $extractor;
 
-    /** @var int */
-    protected $maxDepth;
+    protected int $maxDepth;
 
     public function getExtractor(): string
     {

--- a/src/Metadata/Exception/InvalidConfigException.php
+++ b/src/Metadata/Exception/InvalidConfigException.php
@@ -10,35 +10,28 @@ use Mezzio\Hal\Metadata\MetadataMap;
 use Mezzio\Hal\Metadata\MetadataMapFactory;
 use RuntimeException;
 
-use function gettype;
+use function get_debug_type;
 use function implode;
-use function is_object;
 use function is_string;
 use function sprintf;
 
 class InvalidConfigException extends RuntimeException implements ExceptionInterface
 {
-    /**
-     * @param mixed $config
-     */
-    public static function dueToNonArray($config): self
+    public static function dueToNonArray(mixed $config): self
     {
         return new self(sprintf(
             'Invalid %s configuration; expected an array, but received %s',
             MetadataMap::class,
-            is_object($config) ? $config::class : gettype($config)
+            get_debug_type($config)
         ));
     }
 
-    /**
-     * @param mixed $metadata
-     */
-    public static function dueToNonArrayMetadata($metadata): self
+    public static function dueToNonArrayMetadata(mixed $metadata): self
     {
         return new self(sprintf(
             'Invalid %s metadata item configuration; expected an array, but received %s',
             MetadataMap::class,
-            is_object($metadata) ? $metadata::class : gettype($metadata)
+            get_debug_type($metadata)
         ));
     }
 
@@ -47,14 +40,11 @@ class InvalidConfigException extends RuntimeException implements ExceptionInterf
         return new self('Unable to generate metadata; missing "__class__" element');
     }
 
-    /**
-     * @param mixed $class
-     */
-    public static function dueToInvalidMetadataClass($class): self
+    public static function dueToInvalidMetadataClass(mixed $class): self
     {
         $className = $class;
         if (! is_string($className)) {
-            $className = is_object($class) ? $class::class : gettype($class);
+            $className = get_debug_type($class);
         }
         return new self(sprintf(
             'Invalid metadata class provided: %s is not a class name',

--- a/src/Metadata/MetadataMap.php
+++ b/src/Metadata/MetadataMap.php
@@ -8,11 +8,8 @@ use function class_exists;
 
 class MetadataMap
 {
-    /**
-     * @var array
-     * @psalm-var array<string, AbstractMetadata>
-     */
-    private $map = [];
+    /** @psalm-var array<string, AbstractMetadata> */
+    private array $map = [];
 
     /**
      * @throws Exception\DuplicateMetadataException If metadata matching the

--- a/src/Metadata/RouteBasedCollectionMetadata.php
+++ b/src/Metadata/RouteBasedCollectionMetadata.php
@@ -13,7 +13,7 @@ class RouteBasedCollectionMetadata extends AbstractCollectionMetadata
     public function __construct(
         string $class,
         string $collectionRelation,
-        private string $route,
+        private readonly string $route,
         string $paginationParam = 'page',
         string $paginationParamType = self::TYPE_QUERY,
         private array $routeParams = [],

--- a/src/Metadata/RouteBasedResourceMetadata.php
+++ b/src/Metadata/RouteBasedResourceMetadata.php
@@ -8,34 +8,18 @@ class RouteBasedResourceMetadata extends AbstractResourceMetadata
 {
     private const DEFAULT_RESOURCE_ID = 'id';
 
-    /** @var array */
-    private $identifiersToPlaceHoldersMapping;
-
-    /** @var string */
-    private $resourceIdentifier;
-
-    /** @var string */
-    private $route;
-
-    /** @var array */
-    private $routeParams;
-
     public function __construct(
         string $class,
-        string $route,
+        private readonly string $route,
         string $extractor,
-        string $resourceIdentifier = self::DEFAULT_RESOURCE_ID,
-        array $routeParams = [],
-        array $identifiersToPlaceholdersMapping = [],
+        private readonly string $resourceIdentifier = self::DEFAULT_RESOURCE_ID,
+        private array $routeParams = [],
+        private readonly array $identifiersToPlaceHoldersMapping = [],
         int $maxDepth = 10
     ) {
-        $this->class                            = $class;
-        $this->route                            = $route;
-        $this->extractor                        = $extractor;
-        $this->resourceIdentifier               = $resourceIdentifier;
-        $this->routeParams                      = $routeParams;
-        $this->identifiersToPlaceHoldersMapping = $identifiersToPlaceholdersMapping;
-        $this->maxDepth                         = $maxDepth;
+        $this->class     = $class;
+        $this->extractor = $extractor;
+        $this->maxDepth  = $maxDepth;
     }
 
     public function getRoute(): string

--- a/src/Metadata/UrlBasedCollectionMetadata.php
+++ b/src/Metadata/UrlBasedCollectionMetadata.php
@@ -11,17 +11,13 @@ use function sprintf;
 
 class UrlBasedCollectionMetadata extends AbstractCollectionMetadata
 {
-    /**
-     * URL to use for the `self` relation of the collection.
-     *
-     * @var string
-     */
-    private $url;
-
     public function __construct(
         string $class,
         string $collectionRelation,
-        string $url,
+        /**
+         * URL to use for the `self` relation of the collection.
+         */
+        private readonly string $url,
         string $paginationParam = 'page',
         string $paginationParamType = self::TYPE_QUERY
     ) {
@@ -44,7 +40,6 @@ class UrlBasedCollectionMetadata extends AbstractCollectionMetadata
 
         $this->class               = $class;
         $this->collectionRelation  = $collectionRelation;
-        $this->url                 = $url;
         $this->paginationParam     = $paginationParam;
         $this->paginationParamType = $paginationParamType;
     }

--- a/src/Metadata/UrlBasedResourceMetadata.php
+++ b/src/Metadata/UrlBasedResourceMetadata.php
@@ -6,13 +6,9 @@ namespace Mezzio\Hal\Metadata;
 
 class UrlBasedResourceMetadata extends AbstractResourceMetadata
 {
-    /** @var string */
-    private $url;
-
-    public function __construct(string $class, string $url, string $extractor, int $maxDepth = 10)
+    public function __construct(string $class, private readonly string $url, string $extractor, int $maxDepth = 10)
     {
         $this->class     = $class;
-        $this->url       = $url;
         $this->extractor = $extractor;
         $this->maxDepth  = $maxDepth;
     }

--- a/src/Renderer/JsonRenderer.php
+++ b/src/Renderer/JsonRenderer.php
@@ -15,14 +15,9 @@ class JsonRenderer implements RendererInterface
      * @var int Default flags to use with json_encode()
      */
     const DEFAULT_JSON_FLAGS = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION;
-    // @codingStandardsIgnoreEnd
 
-    /** @var int */
-    private $jsonFlags;
-
-    public function __construct(int $jsonFlags = self::DEFAULT_JSON_FLAGS)
+    public function __construct(private readonly int $jsonFlags = self::DEFAULT_JSON_FLAGS)
     {
-        $this->jsonFlags = $jsonFlags;
     }
 
     public function render(HalResource $resource): string

--- a/src/Renderer/XmlRenderer.php
+++ b/src/Renderer/XmlRenderer.php
@@ -30,8 +30,8 @@ class XmlRenderer implements RendererInterface
     private function createResourceNode(DOMDocument $doc, array $resource, string $resourceRel = 'self'): DOMNode
     {
         // Normalize resource
-        $resource['_links']    = $resource['_links'] ?? [];
-        $resource['_embedded'] = $resource['_embedded'] ?? [];
+        $resource['_links']    ??= [];
+        $resource['_embedded'] ??= [];
 
         $node = $doc->createElement('resource');
 
@@ -98,11 +98,8 @@ class XmlRenderer implements RendererInterface
      * Convert true and false to appropriate strings.
      *
      * In all other cases, return the value as-is.
-     *
-     * @param mixed $value
-     * @return string|mixed
      */
-    private function normalizeConstantValue($value)
+    private function normalizeConstantValue(mixed $value): mixed
     {
         $value = $value === true ? 'true' : $value;
         $value = $value === false ? 'false' : $value;
@@ -170,11 +167,10 @@ class XmlRenderer implements RendererInterface
      * @todo Detect JsonSerializable, and pass to
      *     json_decode(json_encode($object), true), passing the final value
      *     back to createResourceElement()?
-     * @param object $object
      * @throws Exception\InvalidResourceValueException If unable to serialize
      *     the data to a string.
      */
-    private function createDataFromObject($object): string
+    private function createDataFromObject(object $object): string
     {
         if ($object instanceof DateTimeInterface) {
             return $object->format('c');

--- a/src/ResourceGenerator.php
+++ b/src/ResourceGenerator.php
@@ -26,9 +26,9 @@ class ResourceGenerator implements ResourceGeneratorInterface
      * @param LinkGenerator $linkGenerator Route-based link generation.
      */
     public function __construct(
-        private Metadata\MetadataMap $metadataMap,
-        private ContainerInterface $hydrators,
-        private LinkGenerator $linkGenerator
+        private readonly Metadata\MetadataMap $metadataMap,
+        private readonly ContainerInterface $hydrators,
+        private readonly LinkGenerator $linkGenerator
     ) {
     }
 

--- a/src/ResourceGenerator/Exception/InvalidCollectionException.php
+++ b/src/ResourceGenerator/Exception/InvalidCollectionException.php
@@ -6,8 +6,7 @@ namespace Mezzio\Hal\ResourceGenerator\Exception;
 
 use RuntimeException;
 
-use function gettype;
-use function is_object;
+use function get_debug_type;
 use function sprintf;
 
 class InvalidCollectionException extends RuntimeException implements ExceptionInterface
@@ -15,12 +14,12 @@ class InvalidCollectionException extends RuntimeException implements ExceptionIn
     /**
      * @param mixed $instance The invalid collection instance or value.
      */
-    public static function fromInstance($instance, string $class): self
+    public static function fromInstance(mixed $instance, string $class): self
     {
         return new self(sprintf(
             '%s is unable to create a resource for collection of type "%s"; not a Traversable',
             $class,
-            is_object($instance) ? $instance::class : gettype($instance)
+            get_debug_type($instance)
         ));
     }
 }

--- a/src/ResourceGenerator/Exception/InvalidConfigException.php
+++ b/src/ResourceGenerator/Exception/InvalidConfigException.php
@@ -7,33 +7,26 @@ namespace Mezzio\Hal\ResourceGenerator\Exception;
 use Mezzio\Hal\ResourceGenerator;
 use RuntimeException;
 
-use function gettype;
-use function is_object;
+use function get_debug_type;
 use function sprintf;
 
 class InvalidConfigException extends RuntimeException implements ExceptionInterface
 {
-    /**
-     * @param mixed $config
-     */
-    public static function dueToNonArray($config): self
+    public static function dueToNonArray(mixed $config): self
     {
         return new self(sprintf(
             'Invalid %s configuration; expected an array or ArrayAccess instance, but received %s',
             ResourceGenerator::class,
-            is_object($config) ? $config::class : gettype($config)
+            get_debug_type($config)
         ));
     }
 
-    /**
-     * @param mixed $strategies
-     */
-    public static function dueToInvalidStrategies($strategies): self
+    public static function dueToInvalidStrategies(mixed $strategies): self
     {
         return new self(sprintf(
             'Invalid mezzio-hal.resource-generator.strategies configuration; '
             . 'expected an array or Traversable instance, but received %s',
-            is_object($strategies) ? $strategies::class : gettype($strategies)
+            get_debug_type($strategies)
         ));
     }
 }

--- a/src/ResourceGenerator/Exception/InvalidExtractorException.php
+++ b/src/ResourceGenerator/Exception/InvalidExtractorException.php
@@ -7,20 +7,16 @@ namespace Mezzio\Hal\ResourceGenerator\Exception;
 use Laminas\Hydrator\ExtractionInterface;
 use RuntimeException;
 
-use function gettype;
-use function is_object;
+use function get_debug_type;
 use function sprintf;
 
 class InvalidExtractorException extends RuntimeException implements ExceptionInterface
 {
-    /**
-     * @param mixed $extractor
-     */
-    public static function fromInstance($extractor): self
+    public static function fromInstance(mixed $extractor): self
     {
         return new self(sprintf(
             'Invalid extractor "%s" provided in metadata; does not implement %s',
-            is_object($extractor) ? $extractor::class : gettype($extractor),
+            get_debug_type($extractor),
             ExtractionInterface::class
         ));
     }

--- a/src/ResourceGenerator/ExtractCollectionTrait.php
+++ b/src/ResourceGenerator/ExtractCollectionTrait.php
@@ -22,7 +22,7 @@ use function sprintf;
 trait ExtractCollectionTrait
 {
     /** @var string[] */
-    private $paginationTypes = [
+    private array $paginationTypes = [
         AbstractCollectionMetadata::TYPE_PLACEHOLDER,
         AbstractCollectionMetadata::TYPE_QUERY,
     ];
@@ -81,7 +81,7 @@ trait ExtractCollectionTrait
         return $this->createPaginatedCollectionResource(
             $pageCount,
             $data,
-            function (int $page) use ($collection) {
+            function (int $page) use ($collection): void {
                 $collection->setCurrentPageNumber($page);
             },
             $collection,
@@ -116,7 +116,7 @@ trait ExtractCollectionTrait
         return $this->createPaginatedCollectionResource(
             $pageCount,
             $data,
-            function (int $page) use ($query, $perPage) {
+            function (int $page) use ($query, $perPage): void {
                 $query->setFirstResult($perPage * ($page - 1));
             },
             $collection,

--- a/src/ResourceGenerator/RouteBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/RouteBasedCollectionStrategy.php
@@ -91,13 +91,12 @@ class RouteBasedCollectionStrategy implements StrategyInterface
      *     generator in order to generate link based on routing information.
      * @param ServerRequestInterface $request Passed to link generator when
      *     generating link based on routing information.
-     * @return Link
      */
     protected function generateSelfLink(
         Metadata\AbstractCollectionMetadata $metadata,
         ResourceGeneratorInterface $resourceGenerator,
         ServerRequestInterface $request
-    ) {
+    ): Link {
         return $resourceGenerator
             ->getLinkGenerator()
             ->fromRoute(

--- a/src/ResourceGenerator/UrlBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/UrlBasedCollectionStrategy.php
@@ -92,13 +92,12 @@ class UrlBasedCollectionStrategy implements StrategyInterface
      *     abstract.
      * @param ServerRequestInterface $request Ignored; required to fulfill
      *     abstract.
-     * @return Link
      */
     protected function generateSelfLink(
         Metadata\AbstractCollectionMetadata $metadata,
         ResourceGeneratorInterface $resourceGenerator,
         ServerRequestInterface $request
-    ) {
+    ): Link {
         $queryStringArgs = $request->getQueryParams();
         $url             = $metadata->getUrl();
         if ($queryStringArgs !== []) {

--- a/src/ResourceGeneratorFactory.php
+++ b/src/ResourceGeneratorFactory.php
@@ -15,9 +15,6 @@ use function is_string;
 
 class ResourceGeneratorFactory
 {
-    /** @var string */
-    private $linkGeneratorServiceName;
-
     /**
      * Allow serialization
      */
@@ -31,9 +28,8 @@ class ResourceGeneratorFactory
     /**
      * Allow varying behavior based on link generator service name.
      */
-    public function __construct(string $linkGeneratorServiceName = LinkGenerator::class)
+    public function __construct(private readonly string $linkGeneratorServiceName = LinkGenerator::class)
     {
-        $this->linkGeneratorServiceName = $linkGeneratorServiceName;
     }
 
     public function __invoke(ContainerInterface $container): ResourceGenerator

--- a/test/Assertions.php
+++ b/test/Assertions.php
@@ -12,9 +12,8 @@ use Mezzio\Hal\Link;
 use function array_shift;
 use function class_exists;
 use function count;
-use function gettype;
+use function get_debug_type;
 use function in_array;
-use function is_object;
 use function sprintf;
 use function var_export;
 
@@ -34,7 +33,6 @@ trait Assertions
     public static function getLinkByRel(string $rel, HalResource $resource): Link
     {
         $links = $resource->getLinksByRel($rel);
-        self::assertIsArray($links, sprintf("Did not receive list of links for rel %s", $rel));
         self::assertCount(1, $links, sprintf(
             'Received more links than expected (expected 1; received %d) for rel %s',
             count($links),
@@ -50,7 +48,7 @@ trait Assertions
     {
         self::assertThat($actual instanceof Link, self::isTrue(), sprintf(
             'Invalid link encountered of type %s',
-            is_object($actual) ? $actual::class : gettype($actual)
+            get_debug_type($actual)
         ));
 
         self::assertThat(in_array($expectedRel, $actual->getRels(), true), self::isTrue(), sprintf(

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -9,8 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class ConfigProviderTest extends TestCase
 {
-    /** @var ConfigProvider */
-    private $provider;
+    private ConfigProvider $provider;
 
     protected function setUp(): void
     {

--- a/test/HalResponseFactoryFactoryTest.php
+++ b/test/HalResponseFactoryFactoryTest.php
@@ -38,9 +38,7 @@ class HalResponseFactoryFactoryTest extends TestCase
         $jsonRenderer    = $this->createMock(Renderer\JsonRenderer::class);
         $xmlRenderer     = $this->createMock(Renderer\XmlRenderer::class);
         $response        = $this->createMock(ResponseInterface::class);
-        $responseFactory = function () use ($response): ResponseInterface {
-            return $response;
-        };
+        $responseFactory = fn(): ResponseInterface => $response;
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->has(ResponseFactoryInterface::class)->willReturn(false);
@@ -59,9 +57,7 @@ class HalResponseFactoryFactoryTest extends TestCase
     public function testReturnsHalResponseFactoryInstanceWithoutConfiguredDependencies(): void
     {
         $response        = $this->createMock(ResponseInterface::class);
-        $responseFactory = function () use ($response): ResponseInterface {
-            return $response;
-        };
+        $responseFactory = fn(): ResponseInterface => $response;
         $container       = $this->prophesize(ContainerInterface::class);
         $container->has(ResponseFactoryInterface::class)->willReturn(false);
         $container->get(ResponseInterface::class)->willReturn($responseFactory);
@@ -81,12 +77,10 @@ class HalResponseFactoryFactoryTest extends TestCase
         $jsonRenderer    = $this->createMock(Renderer\JsonRenderer::class);
         $xmlRenderer     = $this->createMock(Renderer\XmlRenderer::class);
         $response        = $this->createMock(ResponseInterface::class);
-        $responseFactory = function () use ($response): ResponseInterface {
-            return $response;
-        };
+        $responseFactory = fn(): ResponseInterface => $response;
         $stream          = new class ()
         {
-            public function __invoke()
+            public function __invoke(): void
             {
             }
         };

--- a/test/HalResponseFactoryTest.php
+++ b/test/HalResponseFactoryTest.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 
+use function str_contains;
 use function strlen;
 use function strstr;
 
@@ -20,20 +21,15 @@ class HalResponseFactoryTest extends TestCase
 {
     use TestAsset;
 
-    /** @var ServerRequestInterface&MockObject */
-    private $request;
+    private ServerRequestInterface&MockObject $request;
 
-    /** @var ResponseInterface&MockObject */
-    private $response;
+    private ResponseInterface&MockObject $response;
 
-    /** @var Renderer\JsonRenderer&MockObject */
-    private $jsonRenderer;
+    private Renderer\JsonRenderer&MockObject $jsonRenderer;
 
-    /** @var Renderer\XmlRenderer&MockObject */
-    private $xmlRenderer;
+    private Renderer\XmlRenderer&MockObject $xmlRenderer;
 
-    /** @var HalResponseFactory */
-    private $factory;
+    private HalResponseFactory $factory;
 
     public function setUp(): void
     {
@@ -43,9 +39,7 @@ class HalResponseFactoryTest extends TestCase
         $this->jsonRenderer = $this->createMock(Renderer\JsonRenderer::class);
         $this->xmlRenderer  = $this->createMock(Renderer\XmlRenderer::class);
         $this->factory      = new HalResponseFactory(
-            function (): ResponseInterface {
-                return $this->response;
-            },
+            fn(): ResponseInterface => $this->response,
             $this->jsonRenderer,
             $this->xmlRenderer
         );
@@ -239,7 +233,7 @@ class HalResponseFactoryTest extends TestCase
                     ->expects(self::never())
                     ->method('render');
                 break;
-            case strstr($header, 'xml') !== false:
+            case str_contains($header, 'xml'):
                 $this->xmlRenderer
                     ->expects(self::once())
                     ->method('render')

--- a/test/InMemoryContainer.php
+++ b/test/InMemoryContainer.php
@@ -13,7 +13,7 @@ use function array_key_exists;
 final class InMemoryContainer implements ContainerInterface
 {
     /** @var array<string,mixed> */
-    private $services = [];
+    private array $services = [];
 
     /** {@inheritDoc} */
     public function get(string $id)

--- a/test/LinkGenerator/MezzioUrlGeneratorFactoryTest.php
+++ b/test/LinkGenerator/MezzioUrlGeneratorFactoryTest.php
@@ -16,8 +16,7 @@ use RuntimeException;
 
 class MezzioUrlGeneratorFactoryTest extends TestCase
 {
-    /** @var ContainerInterface&MockObject */
-    private $container;
+    private ContainerInterface&MockObject $container;
 
     public function setUp(): void
     {

--- a/test/LinkTest.php
+++ b/test/LinkTest.php
@@ -4,20 +4,14 @@ declare(strict_types=1);
 
 namespace MezzioTest\Hal;
 
-use ArgumentCountError;
 use InvalidArgumentException;
 use Mezzio\Hal\Link;
+use MezzioTest\Hal\TestAsset\Uri;
 use PHPUnit\Framework\TestCase;
 use Psr\Link\EvolvableLinkInterface;
 
 class LinkTest extends TestCase
 {
-    public function testRequiresRelation(): void
-    {
-        $this->expectException(ArgumentCountError::class);
-        new Link();
-    }
-
     public function testCanConstructLinkWithRelation(): void
     {
         $link = new Link('self');
@@ -64,36 +58,6 @@ class LinkTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $link->getAttributes());
     }
 
-    /**
-     * @psalm-return array<string, array{0: mixed}>
-     */
-    public function invalidRelations(): array
-    {
-        return [
-            'null'         => [null],
-            'false'        => [false],
-            'true'         => [true],
-            'zero'         => [0],
-            'int'          => [1],
-            'zero-float'   => [0.0],
-            'float'        => [1.1],
-            'empty-string' => [''],
-            'array'        => [['link']],
-            'object'       => [(object) ['href' => 'link']],
-        ];
-    }
-
-    /**
-     * @dataProvider invalidRelations
-     * @param mixed $rel
-     */
-    public function testWithRelRaisesExceptionForInvalidRelation($rel): void
-    {
-        $link = new Link('self');
-        $this->expectException(InvalidArgumentException::class);
-        $link->withRel($rel);
-    }
-
     public function testWithRelReturnsSameInstanceIfRelationIsAlreadyPresent(): void
     {
         $link = new Link('self');
@@ -108,17 +72,6 @@ class LinkTest extends TestCase
         $this->assertNotSame($link, $new);
         $this->assertEquals(['self'], $link->getRels());
         $this->assertEquals(['self', 'link'], $new->getRels());
-    }
-
-    /**
-     * @dataProvider invalidRelations
-     * @param mixed $rel
-     */
-    public function testWithoutRelReturnsSameInstanceIfRelationIsInvalid($rel): void
-    {
-        $link = new Link('self');
-        $new  = $link->withoutRel($rel);
-        $this->assertSame($link, $new);
     }
 
     public function testWithoutRelReturnsSameInstanceIfRelationIsNotPresent(): void
@@ -138,90 +91,26 @@ class LinkTest extends TestCase
     }
 
     /**
-     * @psalm-return array<string, array{0: mixed}>
-     */
-    public function invalidUriTypes(): array
-    {
-        return [
-            'null'         => [null],
-            'false'        => [false],
-            'true'         => [true],
-            'zero'         => [0],
-            'int'          => [1],
-            'zero-float'   => [0.0],
-            'float'        => [1.1],
-            'array'        => [['link']],
-            'plain-object' => [(object) ['href' => 'link']],
-        ];
-    }
-
-    /**
-     * @dataProvider invalidUriTypes
-     * @param mixed $uri
-     */
-    public function testWithHrefRaisesExceptionForInvalidUriType($uri): void
-    {
-        $link = new Link('self');
-        $this->expectException(InvalidArgumentException::class);
-        $link->withHref($uri);
-    }
-
-    /**
-     * @psalm-return iterable<string, array{0: string|object}>
+     * @psalm-return iterable<string, array{0: string|Uri}>
      */
     public function validUriTypes(): iterable
     {
         yield 'string' => ['https://example.com/api/link'];
-        yield 'castable-object' => [new TestAsset\Uri('https://example.com/api/link')];
+        yield 'castable-object' => [new Uri('https://example.com/api/link')];
     }
 
     /**
      * @dataProvider validUriTypes
-     * @param string|object $uri
      */
-    public function testWithHrefReturnsNewInstanceWhenUriIsValid($uri): void
+    public function testWithHrefReturnsNewInstanceWhenUriIsValid(string|Uri $uri): void
     {
         $link = new Link('self', 'https://example.com');
         $new  = $link->withHref($uri);
         $this->assertNotSame($link, $new);
 
-        /**
-         * @psalm-suppress PossiblyInvalidCast
-         */
         $stringHref = (string) $uri;
         $this->assertNotEquals($stringHref, $link->getHref());
         $this->assertEquals($stringHref, $new->getHref());
-    }
-
-    /**
-     * @psalm-return array<string, array{0: mixed}>
-     */
-    public function invalidAttributeNames(): array
-    {
-        return [
-            'null'         => [null],
-            'false'        => [false],
-            'true'         => [true],
-            'zero'         => [0],
-            'int'          => [1],
-            'zero-float'   => [0.0],
-            'float'        => [1.1],
-            'empty-string' => [''],
-            'array'        => [['attribute']],
-            'object'       => [(object) ['name' => 'attribute']],
-        ];
-    }
-
-    /**
-     * @dataProvider invalidAttributeNames
-     * @param mixed $name
-     */
-    public function testWithAttributeRaisesExceptionForInvalidAttributeName($name): void
-    {
-        $link = new Link('self');
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('$name');
-        $link->withAttribute($name, 'foo');
     }
 
     /**
@@ -237,9 +126,8 @@ class LinkTest extends TestCase
 
     /**
      * @dataProvider invalidAttributeValues
-     * @param mixed $value
      */
-    public function testWithAttributeRaisesExceptionForInvalidAttributeValue($value): void
+    public function testWithAttributeRaisesExceptionForInvalidAttributeValue(mixed $value): void
     {
         $link = new Link('self');
         $this->expectException(InvalidArgumentException::class);
@@ -266,26 +154,14 @@ class LinkTest extends TestCase
 
     /**
      * @dataProvider validAttributes
-     * @param mixed $value
      */
-    public function testWithAttributeReturnsNewInstanceForValidAttribute(string $name, $value): void
+    public function testWithAttributeReturnsNewInstanceForValidAttribute(string $name, mixed $value): void
     {
         $link = new Link('self');
         $new  = $link->withAttribute($name, $value);
         $this->assertNotSame($link, $new);
         $this->assertEquals([], $link->getAttributes());
         $this->assertEquals([$name => $value], $new->getAttributes());
-    }
-
-    /**
-     * @dataProvider invalidAttributeNames
-     * @param mixed $name
-     */
-    public function testWithoutAttributeReturnsSameInstanceWhenAttributeNameIsInvalid($name): void
-    {
-        $link = new Link('self');
-        $new  = $link->withoutAttribute($name);
-        $this->assertSame($link, $new);
     }
 
     public function testWithoutAttributeReturnsSameInstanceWhenAttributeIsNotPresent(): void

--- a/test/Metadata/MetadataMapFactoryTest.php
+++ b/test/Metadata/MetadataMapFactoryTest.php
@@ -25,11 +25,9 @@ use stdClass;
 
 class MetadataMapFactoryTest extends TestCase
 {
-    /** @var MetadataMapFactory */
-    private $factory;
+    private MetadataMapFactory $factory;
 
-    /** @var ContainerInterface&MockObject */
-    private $container;
+    private ContainerInterface&MockObject $container;
 
     public function setUp(): void
     {

--- a/test/Metadata/MetadataMapTest.php
+++ b/test/Metadata/MetadataMapTest.php
@@ -6,6 +6,7 @@ namespace MezzioTest\Hal\Metadata;
 
 use Generator;
 use Mezzio\Hal\Metadata;
+use Mezzio\Hal\Metadata\MetadataMap;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -15,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 class MetadataMapTest extends TestCase
 {
     /** @psalm-var non-empty-list<class-string<Metadata\AbstractMetadata>> */
-    private $metadataClasses = [
+    private array $metadataClasses = [
         Metadata\AbstractMetadata::class,
         Metadata\AbstractCollectionMetadata::class,
         Metadata\AbstractResourceMetadata::class,
@@ -25,8 +26,7 @@ class MetadataMapTest extends TestCase
         Metadata\UrlBasedResourceMetadata::class,
     ];
 
-    /** @var Metadata\MetadataMap */
-    private $map;
+    private MetadataMap $map;
 
     public function setUp(): void
     {

--- a/test/PHPUnitDeprecatedAssertions.php
+++ b/test/PHPUnitDeprecatedAssertions.php
@@ -228,10 +228,10 @@ trait PHPUnitDeprecatedAssertions
                     }
 
                     return $attribute->getValue($object);
-                } catch (ReflectionException $e) {
+                } catch (ReflectionException) {
                 }
             } while ($reflector = $reflector->getParentClass());
-        } catch (ReflectionException $e) {
+        } catch (ReflectionException) {
         }
 
         throw new Exception(

--- a/test/Psr17ResponseFactoryTraitTest.php
+++ b/test/Psr17ResponseFactoryTraitTest.php
@@ -14,8 +14,7 @@ use Psr\Http\Message\ResponseInterface;
 
 final class Psr17ResponseFactoryTraitTest extends TestCase
 {
-    /** @var Psr17ResponseFactoryTraitImplementation */
-    private $factory;
+    private Psr17ResponseFactoryTraitImplementation $factory;
 
     protected function setUp(): void
     {
@@ -32,9 +31,8 @@ final class Psr17ResponseFactoryTraitTest extends TestCase
             [
                 'dependencies' => [
                     'factories' => [
-                        ResponseInterface::class => function (): ResponseInterface {
-                            return $this->createMock(ResponseInterface::class);
-                        },
+                        ResponseInterface::class
+                            => fn(): ResponseInterface => $this->createMock(ResponseInterface::class),
                     ],
                 ],
             ],
@@ -55,9 +53,7 @@ final class Psr17ResponseFactoryTraitTest extends TestCase
                 'dependencies' => [
                     'delegators' => [
                         ResponseInterface::class => [
-                            function (): ResponseInterface {
-                                return $this->createMock(ResponseInterface::class);
-                            },
+                            fn(): ResponseInterface => $this->createMock(ResponseInterface::class),
                         ],
                     ],
                 ],
@@ -93,9 +89,7 @@ final class Psr17ResponseFactoryTraitTest extends TestCase
         $container->set('config', $config);
         $container->set(ResponseFactoryInterface::class, $responseFactory);
         $response = $this->createMock(ResponseInterface::class);
-        $container->set(ResponseInterface::class, function () use ($response): ResponseInterface {
-            return $response;
-        });
+        $container->set(ResponseInterface::class, fn(): ResponseInterface => $response);
 
         $detectedResponseFactory = ($this->factory)($container);
         self::assertNotSame($responseFactory, $detectedResponseFactory);

--- a/test/ResourceGenerator/DoctrinePaginatorTest.php
+++ b/test/ResourceGenerator/DoctrinePaginatorTest.php
@@ -24,23 +24,17 @@ use function range;
 
 class DoctrinePaginatorTest extends TestCase
 {
-    /** @var RouteBasedCollectionMetadata&MockObject */
-    private $metadata;
+    private RouteBasedCollectionMetadata&MockObject $metadata;
 
-    /** @var LinkGenerator&MockObject */
-    private $linkGenerator;
+    private LinkGenerator&MockObject $linkGenerator;
 
-    /** @var ResourceGenerator&MockObject */
-    private $generator;
+    private ResourceGenerator&MockObject $generator;
 
-    /** @var ServerRequestInterface&MockObject */
-    private $request;
+    private ServerRequestInterface&MockObject $request;
 
-    /** @var Paginator&MockObject */
-    private $paginator;
+    private Paginator&MockObject $paginator;
 
-    /** @var RouteBasedCollectionStrategy */
-    private $strategy;
+    private RouteBasedCollectionStrategy $strategy;
 
     public function setUp(): void
     {
@@ -161,9 +155,7 @@ class DoctrinePaginatorTest extends TestCase
             ->expects(self::never())
             ->method('getAttribute');
 
-        $values = array_map(function ($value) {
-            return (object) ['value' => $value];
-        }, range(46, 60));
+        $values = array_map(fn($value) => (object) ['value' => $value], range(46, 60));
         $this->paginator
             ->method('getIterator')
             ->willReturn(new ArrayIterator($values));
@@ -270,9 +262,7 @@ class DoctrinePaginatorTest extends TestCase
             ->expects(self::never())
             ->method('getAttribute');
 
-        $values = array_map(function ($value) {
-            return (object) ['value' => $value];
-        }, range(46, 60));
+        $values = array_map(fn($value) => (object) ['value' => $value], range(46, 60));
 
         $this->paginator
             ->method('getIterator')
@@ -393,9 +383,7 @@ class DoctrinePaginatorTest extends TestCase
             ->with('page_num', 1)
             ->willReturn(3);
 
-        $values = array_map(function ($value) {
-            return (object) ['value' => $value];
-        }, range(46, 60));
+        $values = array_map(fn($value) => (object) ['value' => $value], range(46, 60));
 
         $this->paginator
             ->method('getIterator')

--- a/test/ResourceGenerator/NestedCollectionResourceGenerationTest.php
+++ b/test/ResourceGenerator/NestedCollectionResourceGenerationTest.php
@@ -140,11 +140,10 @@ class NestedCollectionResourceGenerationTest extends TestCase
     }
 
     /**
-     * @param ServerRequestInterface|ObjectProphecy $request
      * @psalm-param ServerRequestInterface&ObjectProphecy $request
      * @psalm-return ObjectProphecy<LinkGenerator>
      */
-    public function createLinkGenerator($request): ObjectProphecy
+    public function createLinkGenerator(ServerRequestInterface|ObjectProphecy $request): ObjectProphecy
     {
         $linkGenerator = $this->prophesize(LinkGenerator::class);
 
@@ -153,10 +152,8 @@ class NestedCollectionResourceGenerationTest extends TestCase
                 'self',
                 $request->reveal(),
                 'foo-bar',
-                Argument::that(function (array $params) {
-                    return array_key_exists('id', $params)
-                        && $params['id'] === 101010;
-                })
+                Argument::that(fn(array $params): bool => array_key_exists('id', $params)
+                    && $params['id'] === 101010)
             )
             ->willReturn(new Link('self', '/api/foo-bar/1234'));
 
@@ -166,10 +163,8 @@ class NestedCollectionResourceGenerationTest extends TestCase
                     'self',
                     $request->reveal(),
                     'child',
-                    Argument::that(function (array $params) use ($i) {
-                        return array_key_exists('id', $params)
-                            && $params['id'] === $i;
-                    })
+                    Argument::that(fn(array $params): bool => array_key_exists('id', $params)
+                        && $params['id'] === $i)
                 )
                 ->willReturn(new Link('self', '/api/child/' . $i));
         }

--- a/test/ResourceGenerator/ResourceWithNestedInstancesTest.php
+++ b/test/ResourceGenerator/ResourceWithNestedInstancesTest.php
@@ -99,11 +99,10 @@ class ResourceWithNestedInstancesTest extends TestCase
     }
 
     /**
-     * @param ServerRequestInterface|ObjectProphecy $request
      * @psalm-param ServerRequestInterface&ObjectProphecy $request
      * @psalm-return ObjectProphecy<LinkGenerator>
      */
-    public function createLinkGenerator($request): ObjectProphecy
+    public function createLinkGenerator(ServerRequestInterface|ObjectProphecy $request): ObjectProphecy
     {
         $linkGenerator = $this->prophesize(LinkGenerator::class);
 
@@ -112,10 +111,8 @@ class ResourceWithNestedInstancesTest extends TestCase
                 'self',
                 $request->reveal(),
                 'foo-bar',
-                Argument::that(function (array $params) {
-                    return array_key_exists('id', $params)
-                        && $params['id'] === 1234;
-                })
+                Argument::that(fn(array $params): bool => array_key_exists('id', $params)
+                    && $params['id'] === 1234)
             )
             ->willReturn(new Link('self', '/api/foo-bar/1234'));
 
@@ -124,10 +121,8 @@ class ResourceWithNestedInstancesTest extends TestCase
                 'self',
                 $request->reveal(),
                 'child',
-                Argument::that(function (array $params) {
-                    return array_key_exists('id', $params)
-                        && $params['id'] === 9876;
-                })
+                Argument::that(fn(array $params): bool => array_key_exists('id', $params)
+                    && $params['id'] === 9876)
             )
             ->willReturn(new Link('self', '/api/child/9876'));
 

--- a/test/ResourceGenerator/ResourceWithSelfReferringInstanceTest.php
+++ b/test/ResourceGenerator/ResourceWithSelfReferringInstanceTest.php
@@ -63,10 +63,7 @@ final class ResourceWithSelfReferringInstanceTest extends TestCase
         self::assertCount(0, $childResource->getElements());
     }
 
-    /**
-     * @return MetadataMap|ObjectProphecy
-     */
-    public function createMetadataMap()
+    public function createMetadataMap(): MetadataMap|ObjectProphecy
     {
         $metadataMap = $this->prophesize(MetadataMap::class);
 
@@ -86,10 +83,7 @@ final class ResourceWithSelfReferringInstanceTest extends TestCase
         return $metadataMap;
     }
 
-    /**
-     * @return LinkGenerator|ObjectProphecy
-     */
-    public function createLinkGenerator(ObjectProphecy $request)
+    public function createLinkGenerator(ObjectProphecy $request): LinkGenerator|ObjectProphecy
     {
         $linkGenerator = $this->prophesize(LinkGenerator::class);
 
@@ -98,20 +92,15 @@ final class ResourceWithSelfReferringInstanceTest extends TestCase
                 'self',
                 $request->reveal(),
                 'foo-bar',
-                Argument::that(function (array $params): bool {
-                    return array_key_exists('id', $params)
-                        && $params['id'] === 1234;
-                })
+                Argument::that(fn(array $params): bool => array_key_exists('id', $params)
+                    && $params['id'] === 1234)
             )
             ->willReturn(new Link('self', '/api/foo-bar/1234'));
 
         return $linkGenerator;
     }
 
-    /**
-     * @return ObjectProphecy|ContainerInterface
-     */
-    public function createHydrators()
+    public function createHydrators(): ObjectProphecy|ContainerInterface
     {
         $hydratorClass = self::getObjectPropertyHydratorClass();
 

--- a/test/ResourceGenerator/RouteBasedCollectionWithRouteParamsTest.php
+++ b/test/ResourceGenerator/RouteBasedCollectionWithRouteParamsTest.php
@@ -194,23 +194,24 @@ class RouteBasedCollectionWithRouteParamsTest extends TestCase
     }
 
     /**
-     * @param LinkGenerator|ObjectProphecy $linkGenerator
-     * @param ServerRequestInterface|ObjectProphecy $request
      * @psalm-param LinkGenerator&ObjectProphecy $linkGenerator
      * @psalm-param ServerRequestInterface&ObjectProphecy $request
      */
-    private function createLinkGeneratorProphecy($linkGenerator, $request, string $rel, int $page): void
-    {
+    private function createLinkGeneratorProphecy(
+        LinkGenerator|ObjectProphecy $linkGenerator,
+        ServerRequestInterface|ObjectProphecy $request,
+        string $rel,
+        int $page
+    ): void {
+        /** @psalm-suppress InvalidArgument */
         $linkGenerator->fromRoute(
             $rel,
             $request->reveal(),
             'foo-bar',
-            Argument::that(function (array $params) use ($page) {
-                return array_key_exists('foo_id', $params)
-                    && array_key_exists('p', $params)
-                    && $params['foo_id'] === 1234
-                    && $params['p'] === $page;
-            }),
+            Argument::that(fn(array $params): bool => array_key_exists('foo_id', $params)
+                && array_key_exists('p', $params)
+                && $params['foo_id'] === 1234
+                && $params['p'] === $page),
             [
                 'query_1' => 'value_1',
                 'sort'    => 'ASC',
@@ -219,13 +220,13 @@ class RouteBasedCollectionWithRouteParamsTest extends TestCase
     }
 
     /**
-     * @param LinkGenerator|ObjectProphecy $linkGenerator
-     * @param ServerRequestInterface|ObjectProphecy $request
      * @psalm-param LinkGenerator&ObjectProphecy $linkGenerator
      * @psalm-param ServerRequestInterface&ObjectProphecy $request
      */
-    private function createCollectionItems($linkGenerator, $request): array
-    {
+    private function createCollectionItems(
+        LinkGenerator|ObjectProphecy $linkGenerator,
+        ServerRequestInterface|ObjectProphecy $request
+    ): array {
         $instance      = new TestAsset\FooBar();
         $instance->foo = 'BAR';
         $instance->bar = 'BAZ';
@@ -236,17 +237,16 @@ class RouteBasedCollectionWithRouteParamsTest extends TestCase
             $next->id = $i;
             $items[]  = $next;
 
+            /** @psalm-suppress InvalidArgument */
             $linkGenerator
                 ->fromRoute(
                     'self',
                     $request->reveal(),
                     'foo-bar',
-                    Argument::that(function (array $params) use ($i) {
-                        return array_key_exists('foo_id', $params)
-                            && array_key_exists('bar_id', $params)
-                            && $params['foo_id'] === 1234
-                            && $params['bar_id'] === $i;
-                    })
+                    Argument::that(fn(array $params): bool => array_key_exists('foo_id', $params)
+                        && array_key_exists('bar_id', $params)
+                        && $params['foo_id'] === 1234
+                        && $params['bar_id'] === $i)
                 )
                 ->willReturn(new Link('self', '/api/foo/1234/bar/' . $i));
         }

--- a/test/ResourceGenerator/UrlBasedCollectionWithRouteParamsTest.php
+++ b/test/ResourceGenerator/UrlBasedCollectionWithRouteParamsTest.php
@@ -171,13 +171,13 @@ class UrlBasedCollectionWithRouteParamsTest extends TestCase
     }
 
     /**
-     * @param LinkGenerator|ObjectProphecy $linkGenerator
-     * @param ServerRequestInterface|ObjectProphecy $request
      * @psalm-param LinkGenerator&ObjectProphecy $linkGenerator
      * @psalm-param ServerRequestInterface&ObjectProphecy $request
      */
-    private function createCollectionItems($linkGenerator, $request): array
-    {
+    private function createCollectionItems(
+        LinkGenerator|ObjectProphecy $linkGenerator,
+        ServerRequestInterface|ObjectProphecy $request
+    ): array {
         $instance      = new TestAsset\FooBar();
         $instance->foo = 'BAR';
         $instance->bar = 'BAZ';
@@ -188,17 +188,16 @@ class UrlBasedCollectionWithRouteParamsTest extends TestCase
             $next->id = $i;
             $items[]  = $next;
 
+            /** @psalm-suppress InvalidArgument */
             $linkGenerator
                 ->fromRoute(
                     'self',
                     $request->reveal(),
                     'foo-bar',
-                    Argument::that(function (array $params) use ($i) {
-                        return array_key_exists('foo_id', $params)
-                            && array_key_exists('bar_id', $params)
-                            && $params['foo_id'] === 1234
-                            && $params['bar_id'] === $i;
-                    })
+                    Argument::that(fn(array $params): bool => array_key_exists('foo_id', $params)
+                        && array_key_exists('bar_id', $params)
+                        && $params['foo_id'] === 1234
+                        && $params['bar_id'] === $i)
                 )
                 ->willReturn(new Link('self', '/api/foo/1234/bar/' . $i));
         }

--- a/test/ResourceGeneratorFactoryTest.php
+++ b/test/ResourceGeneratorFactoryTest.php
@@ -24,8 +24,7 @@ class ResourceGeneratorFactoryTest extends TestCase
 
     use ProphecyTrait;
 
-    /** @var ObjectProphecy|ContainerInterface */
-    private $container;
+    private ObjectProphecy|ContainerInterface $container;
 
     public function setUp(): void
     {

--- a/test/ResourceGeneratorTest.php
+++ b/test/ResourceGeneratorTest.php
@@ -40,29 +40,18 @@ class ResourceGeneratorTest extends TestCase
 
     use ProphecyTrait;
 
-    /**
-     * @var ObjectProphecy|ServerRequestInterface
-     * @psalm-var ObjectProphecy<ServerRequestInterface>
-     */
-    private $request;
+    /** @psalm-var ObjectProphecy<ServerRequestInterface> */
+    private ObjectProphecy|ServerRequestInterface $request;
 
-    /**
-     * @var ObjectProphecy|ContainerInterface
-     * @psalm-var ObjectProphecy<ContainerInterface>
-     */
-    private $hydrators;
+    /** @psalm-var ObjectProphecy<ContainerInterface> */
+    private ObjectProphecy|ContainerInterface $hydrators;
 
-    /** @var ObjectProphecy|LinkGenerator */
-    private $linkGenerator;
+    private ObjectProphecy|LinkGenerator $linkGenerator;
 
-    /**
-     * @var ObjectProphecy|Metadata\MetadataMap
-     * @psalm-var ObjectProphecy<Metadata\MetadataMap>
-     */
-    private $metadataMap;
+    /** @psalm-var ObjectProphecy<Metadata\MetadataMap> */
+    private ObjectProphecy|Metadata\MetadataMap $metadataMap;
 
-    /** @var ResourceGenerator */
-    private $generator;
+    private ResourceGenerator $generator;
 
     public function setUp(): void
     {
@@ -182,17 +171,16 @@ class ResourceGeneratorTest extends TestCase
         $hydratorClass = self::getObjectPropertyHydratorClass();
 
         $this->hydrators->get($hydratorClass)->willReturn(new $hydratorClass());
+        /** @psalm-suppress InvalidArgument */
         $this->linkGenerator
             ->fromRoute(
                 'self',
                 $this->request->reveal(),
                 'foo-bar',
-                Argument::that(function (array $params) {
-                    return array_key_exists('foo_bar_id', $params)
-                        && array_key_exists('test', $params)
-                        && $params['foo_bar_id'] === 'XXXX-YYYY-ZZZZ'
-                        && $params['test'] === 'param';
-                })
+                Argument::that(fn(array $params): bool => array_key_exists('foo_bar_id', $params)
+                    && array_key_exists('test', $params)
+                    && $params['foo_bar_id'] === 'XXXX-YYYY-ZZZZ'
+                    && $params['test'] === 'param')
             )
             ->willReturn(new Link('self', '/api/foo-bar/XXXX-YYYY-ZZZZ'));
 
@@ -301,17 +289,16 @@ class ResourceGeneratorTest extends TestCase
             $next->id    = $i;
             $instances[] = $next;
 
+            /** @psalm-suppress InvalidArgument */
             $this->linkGenerator
                 ->fromRoute(
                     'self',
                     $this->request->reveal(),
                     'foo-bar',
-                    Argument::that(function (array $params) use ($i) {
-                        return array_key_exists('foo_bar_id', $params)
-                            && array_key_exists('test', $params)
-                            && $params['foo_bar_id'] === $i
-                            && $params['test'] === 'param';
-                    })
+                    Argument::that(fn(array $params): bool => array_key_exists('foo_bar_id', $params)
+                        && array_key_exists('test', $params)
+                        && $params['foo_bar_id'] === $i
+                        && $params['test'] === 'param')
                 )
                 ->willReturn(new Link('self', '/api/foo-bar/' . $i));
         }
@@ -433,17 +420,16 @@ class ResourceGeneratorTest extends TestCase
             $next->id    = $i;
             $instances[] = $next;
 
+            /** @psalm-suppress InvalidArgument */
             $this->linkGenerator
                 ->fromRoute(
                     'self',
                     $this->request->reveal(),
                     'foo-bar',
-                    Argument::that(function (array $params) use ($i) {
-                        return array_key_exists('foo_bar_id', $params)
-                            && array_key_exists('test', $params)
-                            && $params['foo_bar_id'] === $i
-                            && $params['test'] === 'param';
-                    })
+                    Argument::that(fn(array $params): bool => array_key_exists('foo_bar_id', $params)
+                        && array_key_exists('test', $params)
+                        && $params['foo_bar_id'] === $i
+                        && $params['test'] === 'param')
                 )
                 ->willReturn(new Link('self', '/api/foo-bar/' . $i));
         }

--- a/test/TestAsset/StringSerializable.php
+++ b/test/TestAsset/StringSerializable.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace MezzioTest\Hal\TestAsset;
 
-class StringSerializable
+use Stringable;
+
+class StringSerializable implements Stringable
 {
     public function __toString(): string
     {

--- a/test/TestAsset/Uri.php
+++ b/test/TestAsset/Uri.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace MezzioTest\Hal\TestAsset;
 
-class Uri
-{
-    /** @var string */
-    private $uri;
+use Stringable;
 
-    public function __construct(string $uri)
+class Uri implements Stringable
+{
+    public function __construct(private readonly string $uri)
     {
-        $this->uri = $uri;
     }
 
     public function __toString(): string


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This PR introduces strict typing enforcement using Rector.

- Adds Rector to the project and configures it to enforce strict typing rules.
- Applies readonly properties where applicable.
- Adds scalar and class parameter types, return types, and property types throughout the codebase.
- Updates psalm-baseline.xml to remove ignored issues that are now resolved through typing improvements.
- Updates psr/link at least v 1.1
