### PR TITLE
refactor: declare classes and tests as `final`

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -20,8 +20,7 @@ use Mezzio\Hal\ResourceGenerator\RouteBasedResourceStrategy;
 use Mezzio\Hal\ResourceGenerator\UrlBasedCollectionStrategy;
 use Mezzio\Hal\ResourceGenerator\UrlBasedResourceStrategy;
 
-/** @final */
-class ConfigProvider
+final class ConfigProvider
 {
     public function __invoke(): array
     {

--- a/src/Exception/InvalidObjectException.php
+++ b/src/Exception/InvalidObjectException.php
@@ -10,8 +10,7 @@ use Mezzio\Hal\HalResource;
 use function gettype;
 use function sprintf;
 
-/** @final */
-class InvalidObjectException extends InvalidArgumentException implements ExceptionInterface
+final class InvalidObjectException extends InvalidArgumentException implements ExceptionInterface
 {
     /**
      * @param mixed $value Non-object value.

--- a/src/Exception/InvalidResourceValueException.php
+++ b/src/Exception/InvalidResourceValueException.php
@@ -10,8 +10,7 @@ use RuntimeException;
 use function get_debug_type;
 use function sprintf;
 
-/** @final */
-class InvalidResourceValueException extends RuntimeException implements ExceptionInterface
+final class InvalidResourceValueException extends RuntimeException implements ExceptionInterface
 {
     public static function fromValue(mixed $value): self
     {

--- a/src/Exception/InvalidStrategyException.php
+++ b/src/Exception/InvalidStrategyException.php
@@ -10,8 +10,7 @@ use Mezzio\Hal\ResourceGenerator\StrategyInterface;
 use function get_debug_type;
 use function sprintf;
 
-/** @final */
-class InvalidStrategyException extends InvalidArgumentException implements ExceptionInterface
+final class InvalidStrategyException extends InvalidArgumentException implements ExceptionInterface
 {
     public static function forType(string $strategy): self
     {

--- a/src/Exception/UnknownMetadataTypeException.php
+++ b/src/Exception/UnknownMetadataTypeException.php
@@ -9,8 +9,7 @@ use RuntimeException;
 
 use function sprintf;
 
-/** @final */
-class UnknownMetadataTypeException extends RuntimeException implements ExceptionInterface
+final class UnknownMetadataTypeException extends RuntimeException implements ExceptionInterface
 {
     public static function forMetadata(AbstractMetadata $metadata): self
     {

--- a/src/HalResponseFactory.php
+++ b/src/HalResponseFactory.php
@@ -15,8 +15,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use function is_callable;
 use function str_contains;
 
-/** @final */
-class HalResponseFactory
+final class HalResponseFactory
 {
     /**
      * @var string Default mediatype to use as the base Content-Type, minus the format.

--- a/src/HalResponseFactoryFactory.php
+++ b/src/HalResponseFactoryFactory.php
@@ -18,7 +18,7 @@ use Psr\Container\ContainerInterface;
  *
  * @final
  */
-class HalResponseFactoryFactory
+final class HalResponseFactoryFactory
 {
     use Psr17ResponseFactoryTrait;
 

--- a/src/LinkGenerator/MezzioUrlGenerator.php
+++ b/src/LinkGenerator/MezzioUrlGenerator.php
@@ -8,8 +8,7 @@ use Mezzio\Helper\ServerUrlHelper;
 use Mezzio\Helper\UrlHelper;
 use Psr\Http\Message\ServerRequestInterface;
 
-/** @final */
-class MezzioUrlGenerator implements UrlGeneratorInterface
+final class MezzioUrlGenerator implements UrlGeneratorInterface
 {
     public function __construct(
         private readonly UrlHelper $urlHelper,

--- a/src/LinkGenerator/MezzioUrlGeneratorFactory.php
+++ b/src/LinkGenerator/MezzioUrlGeneratorFactory.php
@@ -11,8 +11,7 @@ use RuntimeException;
 
 use function sprintf;
 
-/** @final */
-class MezzioUrlGeneratorFactory
+final class MezzioUrlGeneratorFactory
 {
     /**
      * Allow serialization

--- a/src/LinkGeneratorFactory.php
+++ b/src/LinkGeneratorFactory.php
@@ -6,8 +6,7 @@ namespace Mezzio\Hal;
 
 use Psr\Container\ContainerInterface;
 
-/** @final */
-class LinkGeneratorFactory
+final class LinkGeneratorFactory
 {
     /**
      * Allow serialization

--- a/src/Metadata/Exception/DuplicateMetadataException.php
+++ b/src/Metadata/Exception/DuplicateMetadataException.php
@@ -8,8 +8,7 @@ use DomainException;
 
 use function sprintf;
 
-/** @final */
-class DuplicateMetadataException extends DomainException implements ExceptionInterface
+final class DuplicateMetadataException extends DomainException implements ExceptionInterface
 {
     public static function create(string $class): self
     {

--- a/src/Metadata/Exception/InvalidConfigException.php
+++ b/src/Metadata/Exception/InvalidConfigException.php
@@ -15,8 +15,7 @@ use function implode;
 use function is_string;
 use function sprintf;
 
-/** @final */
-class InvalidConfigException extends RuntimeException implements ExceptionInterface
+final class InvalidConfigException extends RuntimeException implements ExceptionInterface
 {
     public static function dueToNonArray(mixed $config): self
     {

--- a/src/Metadata/Exception/UndefinedClassException.php
+++ b/src/Metadata/Exception/UndefinedClassException.php
@@ -8,8 +8,7 @@ use UnexpectedValueException;
 
 use function sprintf;
 
-/** @final */
-class UndefinedClassException extends UnexpectedValueException implements ExceptionInterface
+final class UndefinedClassException extends UnexpectedValueException implements ExceptionInterface
 {
     public static function create(string $class): self
     {

--- a/src/Metadata/Exception/UndefinedMetadataException.php
+++ b/src/Metadata/Exception/UndefinedMetadataException.php
@@ -8,8 +8,7 @@ use RuntimeException;
 
 use function sprintf;
 
-/** @final */
-class UndefinedMetadataException extends RuntimeException implements ExceptionInterface
+final class UndefinedMetadataException extends RuntimeException implements ExceptionInterface
 {
     public static function create(string $class): self
     {

--- a/src/Metadata/RouteBasedCollectionMetadataFactory.php
+++ b/src/Metadata/RouteBasedCollectionMetadataFactory.php
@@ -7,8 +7,7 @@ namespace Mezzio\Hal\Metadata;
 use function array_intersect;
 use function array_keys;
 
-/** @final */
-class RouteBasedCollectionMetadataFactory implements MetadataFactoryInterface
+final class RouteBasedCollectionMetadataFactory implements MetadataFactoryInterface
 {
     /**
      * Creates a RouteBasedCollectionMetadata based on the MetadataMap configuration.

--- a/src/Metadata/RouteBasedResourceMetadataFactory.php
+++ b/src/Metadata/RouteBasedResourceMetadataFactory.php
@@ -7,8 +7,7 @@ namespace Mezzio\Hal\Metadata;
 use function array_intersect;
 use function array_keys;
 
-/** @final */
-class RouteBasedResourceMetadataFactory implements MetadataFactoryInterface
+final class RouteBasedResourceMetadataFactory implements MetadataFactoryInterface
 {
     /**
      * Creates a RouteBasedResourceMetadata based on the MetadataMap configuration.

--- a/src/Metadata/UrlBasedCollectionMetadataFactory.php
+++ b/src/Metadata/UrlBasedCollectionMetadataFactory.php
@@ -7,8 +7,7 @@ namespace Mezzio\Hal\Metadata;
 use function array_intersect;
 use function array_keys;
 
-/** @final */
-class UrlBasedCollectionMetadataFactory implements MetadataFactoryInterface
+final class UrlBasedCollectionMetadataFactory implements MetadataFactoryInterface
 {
     /**
      * Creates a UrlBasedCollectionMetadata based on the MetadataMap configuration.

--- a/src/Metadata/UrlBasedResourceMetadataFactory.php
+++ b/src/Metadata/UrlBasedResourceMetadataFactory.php
@@ -7,8 +7,7 @@ namespace Mezzio\Hal\Metadata;
 use function array_intersect;
 use function array_keys;
 
-/** @final */
-class UrlBasedResourceMetadataFactory implements MetadataFactoryInterface
+final class UrlBasedResourceMetadataFactory implements MetadataFactoryInterface
 {
     /**
      * Creates a UrlBasedResourceMetadata based on the MetadataMap configuration.

--- a/src/ResourceGenerator/Exception/InvalidCollectionException.php
+++ b/src/ResourceGenerator/Exception/InvalidCollectionException.php
@@ -9,8 +9,7 @@ use RuntimeException;
 use function get_debug_type;
 use function sprintf;
 
-/** @final */
-class InvalidCollectionException extends RuntimeException implements ExceptionInterface
+final class InvalidCollectionException extends RuntimeException implements ExceptionInterface
 {
     /**
      * @param mixed $instance The invalid collection instance or value.

--- a/src/ResourceGenerator/Exception/InvalidConfigException.php
+++ b/src/ResourceGenerator/Exception/InvalidConfigException.php
@@ -10,8 +10,7 @@ use RuntimeException;
 use function get_debug_type;
 use function sprintf;
 
-/** @final */
-class InvalidConfigException extends RuntimeException implements ExceptionInterface
+final class InvalidConfigException extends RuntimeException implements ExceptionInterface
 {
     public static function dueToNonArray(mixed $config): self
     {

--- a/src/ResourceGenerator/Exception/InvalidExtractorException.php
+++ b/src/ResourceGenerator/Exception/InvalidExtractorException.php
@@ -10,8 +10,7 @@ use RuntimeException;
 use function get_debug_type;
 use function sprintf;
 
-/** @final */
-class InvalidExtractorException extends RuntimeException implements ExceptionInterface
+final class InvalidExtractorException extends RuntimeException implements ExceptionInterface
 {
     public static function fromInstance(mixed $extractor): self
     {

--- a/src/ResourceGenerator/Exception/OutOfBoundsException.php
+++ b/src/ResourceGenerator/Exception/OutOfBoundsException.php
@@ -6,7 +6,6 @@ namespace Mezzio\Hal\ResourceGenerator\Exception;
 
 use OutOfBoundsException as BaseOutOfBoundsException;
 
-/** @final */
-class OutOfBoundsException extends BaseOutOfBoundsException implements ExceptionInterface
+final class OutOfBoundsException extends BaseOutOfBoundsException implements ExceptionInterface
 {
 }

--- a/src/ResourceGenerator/Exception/UnexpectedMetadataTypeException.php
+++ b/src/ResourceGenerator/Exception/UnexpectedMetadataTypeException.php
@@ -10,8 +10,7 @@ use RuntimeException;
 
 use function sprintf;
 
-/** @final */
-class UnexpectedMetadataTypeException extends RuntimeException implements ExceptionInterface
+final class UnexpectedMetadataTypeException extends RuntimeException implements ExceptionInterface
 {
     public static function forMetadata(AbstractMetadata $metadata, string $strategy, string $expected): self
     {

--- a/src/ResourceGenerator/RouteBasedResourceStrategy.php
+++ b/src/ResourceGenerator/RouteBasedResourceStrategy.php
@@ -13,8 +13,7 @@ use Stringable;
 use function array_key_exists;
 use function is_scalar;
 
-/** @final */
-class RouteBasedResourceStrategy implements StrategyInterface
+final class RouteBasedResourceStrategy implements StrategyInterface
 {
     use ExtractInstanceTrait;
 

--- a/src/ResourceGenerator/UrlBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/UrlBasedCollectionStrategy.php
@@ -23,8 +23,7 @@ use function str_replace;
 use const PHP_URL_FRAGMENT;
 use const PHP_URL_QUERY;
 
-/** @final */
-class UrlBasedCollectionStrategy implements StrategyInterface
+final class UrlBasedCollectionStrategy implements StrategyInterface
 {
     use ExtractCollectionTrait, GenerateSelfLinkTrait {
         GenerateSelfLinkTrait::generateSelfLink insteadof ExtractCollectionTrait;
@@ -46,7 +45,7 @@ class UrlBasedCollectionStrategy implements StrategyInterface
         }
 
         if (! $instance instanceof Traversable) {
-            throw Exception\InvalidCollectionException::fromInstance($instance, static::class);
+            throw Exception\InvalidCollectionException::fromInstance($instance, self::class);
         }
 
         return $this->extractCollection($instance, $metadata, $resourceGenerator, $request, $depth);

--- a/src/ResourceGenerator/UrlBasedResourceStrategy.php
+++ b/src/ResourceGenerator/UrlBasedResourceStrategy.php
@@ -10,8 +10,7 @@ use Mezzio\Hal\Metadata;
 use Mezzio\Hal\ResourceGeneratorInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-/** @final */
-class UrlBasedResourceStrategy implements StrategyInterface
+final class UrlBasedResourceStrategy implements StrategyInterface
 {
     use ExtractInstanceTrait;
 

--- a/src/ResourceGeneratorFactory.php
+++ b/src/ResourceGeneratorFactory.php
@@ -13,8 +13,7 @@ use Traversable;
 use function is_array;
 use function is_string;
 
-/** @final */
-class ResourceGeneratorFactory
+final class ResourceGeneratorFactory
 {
     /**
      * Allow serialization

--- a/test/TestAsset/TestMetadataMapFactory.php
+++ b/test/TestAsset/TestMetadataMapFactory.php
@@ -6,10 +6,9 @@ namespace MezzioTest\Hal\TestAsset;
 
 use Mezzio\Hal\Metadata\MetadataMapFactory;
 
-/** @final */
-class TestMetadataMapFactory extends MetadataMapFactory
+final class TestMetadataMapFactory extends MetadataMapFactory
 {
-    protected function createTestMetadata(): TestMetadata
+    public function createTestMetadata(): TestMetadata
     {
         return new TestMetadata();
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | yes
| QA            | yes

### Description

This PR makes all eligible classes `final`.  
Some classes remain non-final because they are required for mocking in tests or represent intentional extension points.

**What was done**
- Declared `final` on all classes that are not designed for inheritance.
- Excluded classes that:
  - Are mocked in tests and require non-final status.
  - Are explicitly intended as extension points.
- Updated tests where necessary to account for `final` declarations.

**Impact**
- This is a **backwards-incompatible change**: projects extending classes that are now `final` will need to refactor.
