### PR TITLE
refactor: replace mocked metadata with direct init and declare remaining metadata classes as `final`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -791,14 +791,12 @@
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$this->createMock(LinkGenerator::class)]]></code>
       <code><![CDATA[$this->createMock(ResourceGenerator::class)]]></code>
-      <code><![CDATA[$this->createMock(RouteBasedCollectionMetadata::class)]]></code>
     </InvalidPropertyAssignmentValue>
     <MixedMethodCall>
       <code><![CDATA[expects]]></code>
       <code><![CDATA[expects]]></code>
       <code><![CDATA[expects]]></code>
       <code><![CDATA[expects]]></code>
-      <code><![CDATA[expects]]></code>
       <code><![CDATA[method]]></code>
       <code><![CDATA[method]]></code>
       <code><![CDATA[method]]></code>
@@ -808,45 +806,6 @@
       <code><![CDATA[method]]></code>
       <code><![CDATA[method]]></code>
       <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[method]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
-      <code><![CDATA[willReturn]]></code>
       <code><![CDATA[willReturn]]></code>
       <code><![CDATA[willReturn]]></code>
       <code><![CDATA[willReturn]]></code>
@@ -868,10 +827,6 @@
       <code><![CDATA[$this->generator]]></code>
       <code><![CDATA[$this->generator]]></code>
       <code><![CDATA[$this->generator]]></code>
-      <code><![CDATA[$this->metadata]]></code>
-      <code><![CDATA[$this->metadata]]></code>
-      <code><![CDATA[$this->metadata]]></code>
-      <code><![CDATA[$this->metadata]]></code>
     </NoValue>
   </file>
   <file src="test/ResourceGenerator/ExceptionTest.php">

--- a/src/Metadata/RouteBasedCollectionMetadata.php
+++ b/src/Metadata/RouteBasedCollectionMetadata.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Mezzio\Hal\Metadata;
 
-/** @final */
-class RouteBasedCollectionMetadata extends AbstractCollectionMetadata
+final class RouteBasedCollectionMetadata extends AbstractCollectionMetadata
 {
     /**
      * @param array<string, mixed> $routeParams

--- a/src/Metadata/RouteBasedResourceMetadata.php
+++ b/src/Metadata/RouteBasedResourceMetadata.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Mezzio\Hal\Metadata;
 
-/** @final */
-class RouteBasedResourceMetadata extends AbstractResourceMetadata
+final class RouteBasedResourceMetadata extends AbstractResourceMetadata
 {
     private const DEFAULT_RESOURCE_ID = 'id';
 

--- a/src/Metadata/UrlBasedCollectionMetadata.php
+++ b/src/Metadata/UrlBasedCollectionMetadata.php
@@ -9,8 +9,7 @@ use InvalidArgumentException;
 use function in_array;
 use function sprintf;
 
-/** @final */
-class UrlBasedCollectionMetadata extends AbstractCollectionMetadata
+final class UrlBasedCollectionMetadata extends AbstractCollectionMetadata
 {
     public function __construct(
         string $class,

--- a/src/Metadata/UrlBasedResourceMetadata.php
+++ b/src/Metadata/UrlBasedResourceMetadata.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Mezzio\Hal\Metadata;
 
-/** @final */
-class UrlBasedResourceMetadata extends AbstractResourceMetadata
+final class UrlBasedResourceMetadata extends AbstractResourceMetadata
 {
     public function __construct(string $class, private readonly string $url, string $extractor, int $maxDepth = 10)
     {

--- a/test/Metadata/MetadataMapTest.php
+++ b/test/Metadata/MetadataMapTest.php
@@ -5,27 +5,13 @@ declare(strict_types=1);
 namespace MezzioTest\Hal\Metadata;
 
 use Generator;
+use Laminas\Hydrator\ObjectPropertyHydrator;
 use Mezzio\Hal\Metadata;
 use Mezzio\Hal\Metadata\MetadataMap;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @see MockObject
- */
 final class MetadataMapTest extends TestCase
 {
-    /** @psalm-var non-empty-list<class-string<Metadata\AbstractMetadata>> */
-    private array $metadataClasses = [
-        Metadata\AbstractMetadata::class,
-        Metadata\AbstractCollectionMetadata::class,
-        Metadata\AbstractResourceMetadata::class,
-        Metadata\RouteBasedCollectionMetadata::class,
-        Metadata\RouteBasedResourceMetadata::class,
-        Metadata\UrlBasedCollectionMetadata::class,
-        Metadata\UrlBasedResourceMetadata::class,
-    ];
-
     private MetadataMap $map;
 
     public function setUp(): void
@@ -36,19 +22,31 @@ final class MetadataMapTest extends TestCase
     /**
      * @psalm-return Generator<class-string<Metadata\AbstractMetadata>, array{
      *  0: class-string<Metadata\AbstractMetadata>,
-     *  1: Metadata\AbstractMetadata&MockObject
+     *  1: Metadata\AbstractMetadata
      * }>
      */
     public function validMetadataTypes(): Generator
     {
-        foreach ($this->metadataClasses as $class) {
-            $metadata = $this->createMock($class);
-            $metadata
-                ->method('getClass')
-                ->willReturn($class);
+        $class = Metadata\RouteBasedCollectionMetadata::class;
+        yield Metadata\RouteBasedCollectionMetadata::class => [
+            $class,
+            new Metadata\RouteBasedCollectionMetadata($class, 'foo-bar', 'foo-bar'),
+        ];
 
-            yield $class => [$class, $metadata];
-        }
+        yield Metadata\RouteBasedResourceMetadata::class => [
+            $class,
+            new Metadata\RouteBasedResourceMetadata($class, 'foo-bar', ObjectPropertyHydrator::class),
+        ];
+
+        yield Metadata\UrlBasedCollectionMetadata::class => [
+            $class,
+            new Metadata\UrlBasedCollectionMetadata($class, 'foo-bar', 'foo-bar'),
+        ];
+
+        yield Metadata\UrlBasedResourceMetadata::class => [
+            $class,
+            new Metadata\UrlBasedResourceMetadata($class, 'foo-bar', ObjectPropertyHydrator::class),
+        ];
     }
 
     /**

--- a/test/ResourceGenerator/DoctrinePaginatorTest.php
+++ b/test/ResourceGenerator/DoctrinePaginatorTest.php
@@ -17,6 +17,7 @@ use Mezzio\Hal\ResourceGenerator\RouteBasedCollectionStrategy;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
+use stdClass;
 
 use function array_map;
 use function count;
@@ -24,8 +25,6 @@ use function range;
 
 final class DoctrinePaginatorTest extends TestCase
 {
-    private RouteBasedCollectionMetadata&MockObject $metadata;
-
     private LinkGenerator&MockObject $linkGenerator;
 
     private ResourceGenerator&MockObject $generator;
@@ -38,7 +37,6 @@ final class DoctrinePaginatorTest extends TestCase
 
     public function setUp(): void
     {
-        $this->metadata      = $this->createMock(RouteBasedCollectionMetadata::class);
         $this->linkGenerator = $this->createMock(LinkGenerator::class);
         $this->generator     = $this->createMock(ResourceGenerator::class);
         $this->request       = $this->createMock(ServerRequestInterface::class);
@@ -75,13 +73,15 @@ final class DoctrinePaginatorTest extends TestCase
             ->method('count')
             ->willReturn($numPages);
 
-        $this->metadata
-            ->method('getPaginationParamType')
-            ->willReturn(RouteBasedCollectionMetadata::TYPE_QUERY);
-
-        $this->metadata
-            ->method('getPaginationParam')
-            ->willReturn('page_num');
+        $metadata = new RouteBasedCollectionMetadata(
+            stdClass::class,
+            'test',
+            'test',
+            'page_num',
+            RouteBasedCollectionMetadata::TYPE_QUERY,
+            [],
+            []
+        );
 
         $this->request
             ->method('getQueryParams')
@@ -90,7 +90,7 @@ final class DoctrinePaginatorTest extends TestCase
         $this->expectException(OutOfBoundsException::class);
         $this->strategy->createResource(
             $this->paginator,
-            $this->metadata,
+            $metadata,
             $this->generator,
             $this->request
         );
@@ -111,29 +111,15 @@ final class DoctrinePaginatorTest extends TestCase
             ->method('count')
             ->willReturn(100);
 
-        $this->metadata
-            ->method('getPaginationParamType')
-            ->willReturn('unknown');
-
-        $this->metadata
-            ->expects(self::never())
-            ->method('getPaginationParam');
-
-        $this->metadata
-            ->method('getRouteParams')
-            ->willReturn([]);
-
-        $this->metadata
-            ->method('getQueryStringArguments')
-            ->willReturn([]);
-
-        $this->metadata
-            ->method('getRoute')
-            ->willReturn('test');
-
-        $this->metadata
-            ->method('getCollectionRelation')
-            ->willReturn('test');
+        $metadata = new RouteBasedCollectionMetadata(
+            stdClass::class,
+            'test',
+            'test',
+            'page_num',
+            'unknown',
+            [],
+            []
+        );
 
         $this->request
             ->expects(self::once())
@@ -191,7 +177,7 @@ final class DoctrinePaginatorTest extends TestCase
 
         $this->strategy->createResource(
             $this->paginator,
-            $this->metadata,
+            $metadata,
             $this->generator,
             $this->request
         );
@@ -218,29 +204,15 @@ final class DoctrinePaginatorTest extends TestCase
             ->method('count')
             ->willReturn(100);
 
-        $this->metadata
-            ->method('getPaginationParamType')
-            ->willReturn(RouteBasedCollectionMetadata::TYPE_QUERY);
-
-        $this->metadata
-            ->method('getPaginationParam')
-            ->willReturn('page_num');
-
-        $this->metadata
-            ->method('getRouteParams')
-            ->willReturn([]);
-
-        $this->metadata
-            ->method('getQueryStringArguments')
-            ->willReturn([]);
-
-        $this->metadata
-            ->method('getRoute')
-            ->willReturn('test');
-
-        $this->metadata
-            ->method('getCollectionRelation')
-            ->willReturn('test');
+        $metadata = new RouteBasedCollectionMetadata(
+            stdClass::class,
+            'test',
+            'test',
+            'page_num',
+            RouteBasedCollectionMetadata::TYPE_QUERY,
+            [],
+            []
+        );
 
         $this->request
             ->expects(self::exactly(6))
@@ -311,7 +283,7 @@ final class DoctrinePaginatorTest extends TestCase
 
         $resource = $this->strategy->createResource(
             $this->paginator,
-            $this->metadata,
+            $metadata,
             $this->generator,
             $this->request
         );
@@ -337,29 +309,15 @@ final class DoctrinePaginatorTest extends TestCase
             ->willReturn($query);
         $this->paginator->method('count')->willReturn(100);
 
-        $this->metadata
-            ->method('getPaginationParamType')
-            ->willReturn(RouteBasedCollectionMetadata::TYPE_PLACEHOLDER);
-
-        $this->metadata
-            ->method('getPaginationParam')
-            ->willReturn('page_num');
-
-        $this->metadata
-            ->method('getRouteParams')
-            ->willReturn([]);
-
-        $this->metadata
-            ->method('getQueryStringArguments')
-            ->willReturn([]);
-
-        $this->metadata
-            ->method('getRoute')
-            ->willReturn('test');
-
-        $this->metadata
-            ->method('getCollectionRelation')
-            ->willReturn('test');
+        $metadata = new RouteBasedCollectionMetadata(
+            stdClass::class,
+            'test',
+            'test',
+            'page_num',
+            RouteBasedCollectionMetadata::TYPE_PLACEHOLDER,
+            [],
+            []
+        );
 
         $this->request
             ->expects(self::exactly(5))
@@ -431,7 +389,7 @@ final class DoctrinePaginatorTest extends TestCase
 
         $resource = $this->strategy->createResource(
             $this->paginator,
-            $this->metadata,
+            $metadata,
             $this->generator,
             $this->request
         );

--- a/test/ResourceGenerator/RouteBasedResourceStrategyTest.php
+++ b/test/ResourceGenerator/RouteBasedResourceStrategyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MezzioTest\Hal\ResourceGenerator;
 
 use Laminas\Hydrator\ExtractionInterface;
+use Laminas\Hydrator\ObjectPropertyHydrator;
 use Mezzio\Hal\HalResource;
 use Mezzio\Hal\Link;
 use Mezzio\Hal\LinkGenerator;
@@ -13,6 +14,7 @@ use Mezzio\Hal\Metadata\RouteBasedResourceMetadata;
 use Mezzio\Hal\ResourceGenerator\Exception\UnexpectedMetadataTypeException;
 use Mezzio\Hal\ResourceGenerator\RouteBasedResourceStrategy;
 use Mezzio\Hal\ResourceGeneratorInterface;
+use MezzioTest\Hal\TestAsset\FooBar;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -391,26 +393,23 @@ final class RouteBasedResourceStrategyTest extends TestCase
 
     private function createRouteBasedMetadata(string $route): RouteBasedResourceMetadata
     {
-        $metadata = $this->createMock(RouteBasedResourceMetadata::class);
-        $metadata->method('getRoute')->willReturn($route);
-        $metadata->method('getRouteParams')->willReturn([]);
-        $metadata->method('getIdentifiersToPlaceholdersMapping')->willReturn([]);
-        $metadata->method('hasReachedMaxDepth')->willReturn(false);
-
-        return $metadata;
+        return new RouteBasedResourceMetadata(
+            FooBar::class,
+            $route,
+            ObjectPropertyHydrator::class,
+        );
     }
 
     private function createRouteBasedMetadataWithPlaceholders(
         string $route,
         array $placeholders
     ): RouteBasedResourceMetadata {
-        $metadata = $this->createMock(RouteBasedResourceMetadata::class);
-        $metadata->method('getRoute')->willReturn($route);
-        $metadata->method('getRouteParams')->willReturn([]);
-        $metadata->method('getIdentifiersToPlaceholdersMapping')->willReturn($placeholders);
-        $metadata->method('hasReachedMaxDepth')->willReturn(false);
-
-        return $metadata;
+        return new RouteBasedResourceMetadata(
+            FooBar::class,
+            $route,
+            ObjectPropertyHydrator::class,
+            identifiersToPlaceHoldersMapping: $placeholders,
+        );
     }
 
     private function createResourceGenerator(): ResourceGeneratorInterface


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This PR refactors metadata classes by:

- Replacing `@final` annotations with actual `final` class declarations.  
- Updating related tests to remove mocks, since final classes cannot be mocked.  