### PR TITLE
Drop support for PHP 8.1, add support for PHP 8.5

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,6 +1,6 @@
 {
     "ignore_php_platform_requirements": {
-        "8.4": false
+        "8.5": true
     },
     "backwardCompatibilityCheck": true
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "8.1.99"
+            "php": "8.2.99"
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
@@ -38,7 +38,7 @@
         }
     },
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "ext-dom": "*",
         "ext-json": "*",
         "psr/container": "^1.1.2 || ^2.0.2",
@@ -53,9 +53,9 @@
         "laminas/laminas-coding-standard": "~3.1.0",
         "laminas/laminas-hydrator": "^4.16",
         "laminas/laminas-paginator": "^2.19.0",
-        "mezzio/mezzio-helpers": "^5.19",
+        "mezzio/mezzio-helpers": "^5.20",
         "phpspec/prophecy-phpunit": "^2.4.0",
-        "phpunit/phpunit": "^9.6.27",
+        "phpunit/phpunit": "^9.6.29",
         "psalm/plugin-phpunit": "^0.19.5",
         "vimeo/psalm": "^6.13.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7dfe4677a64a1a3091c9b2041f7978fa",
+    "content-hash": "bf5f868649a844f1080d315872f59a25",
     "packages": [
         {
             "name": "psr/container",
@@ -2996,30 +2996,30 @@
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.20.0",
+            "version": "3.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "8974a1213be42c3e2f70b2c27b17f910291ab2f4"
+                "reference": "b1c81514cfe158aadf724c42b34d3d0a8164c096"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/8974a1213be42c3e2f70b2c27b17f910291ab2f4",
-                "reference": "8974a1213be42c3e2f70b2c27b17f910291ab2f4",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/b1c81514cfe158aadf724c42b34d3d0a8164c096",
+                "reference": "b1c81514cfe158aadf724c42b34d3d0a8164c096",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^3.0",
-                "phpbench/phpbench": "^1.3.1",
-                "phpunit/phpunit": "^10.5.38",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "vimeo/psalm": "^5.26.1"
+                "laminas/laminas-coding-standard": "^3.1.0",
+                "phpbench/phpbench": "^1.4.1",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
             },
             "type": "library",
             "autoload": {
@@ -3051,7 +3051,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-10-29T13:46:07+00:00"
+            "time": "2025-10-11T18:13:12+00:00"
         },
         {
             "name": "league/uri",
@@ -3229,21 +3229,21 @@
         },
         {
             "name": "mezzio/mezzio-helpers",
-            "version": "5.19.0",
+            "version": "5.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio-helpers.git",
-                "reference": "9adec72d8437e2c5058d28f69ce569b7a666b958"
+                "reference": "a26ba04bd449d5cdb5ad38b17ce672365dbc9d90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-helpers/zipball/9adec72d8437e2c5058d28f69ce569b7a666b958",
-                "reference": "9adec72d8437e2c5058d28f69ce569b7a666b958",
+                "url": "https://api.github.com/repos/mezzio/mezzio-helpers/zipball/a26ba04bd449d5cdb5ad38b17ce672365dbc9d90",
+                "reference": "a26ba04bd449d5cdb5ad38b17ce672365dbc9d90",
                 "shasum": ""
             },
             "require": {
-                "mezzio/mezzio-router": "^3.0 || ^4.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "mezzio/mezzio-router": "^3.18 || ^4.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
                 "psr/container": "^1.0 || ^2.0",
                 "psr/http-message": "^1.0.1 || ^2.0.0",
                 "psr/http-server-middleware": "^1.0"
@@ -3257,10 +3257,10 @@
             "require-dev": {
                 "ext-json": "*",
                 "laminas/laminas-coding-standard": "~3.1.0",
-                "laminas/laminas-diactoros": "^3.5",
-                "phpunit/phpunit": "^10.5.45",
+                "laminas/laminas-diactoros": "^3.6",
+                "phpunit/phpunit": "^11.5.42",
                 "psalm/plugin-phpunit": "^0.19.5",
-                "vimeo/psalm": "^6.10.1"
+                "vimeo/psalm": "^6.13.1"
             },
             "suggest": {
                 "ext-json": "If you wish to use the JsonStrategy with BodyParamsMiddleware"
@@ -3304,25 +3304,25 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-09-04T11:08:16+00:00"
+            "time": "2025-10-11T08:40:34+00:00"
         },
         {
             "name": "mezzio/mezzio-router",
-            "version": "4.0.1",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio-router.git",
-                "reference": "851fb024aa9ebd9690450f838d63e0368d188aa7"
+                "reference": "82846ece61e2c7f903baf734de9fcb47f89f999c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-router/zipball/851fb024aa9ebd9690450f838d63e0368d188aa7",
-                "reference": "851fb024aa9ebd9690450f838d63e0368d188aa7",
+                "url": "https://api.github.com/repos/mezzio/mezzio-router/zipball/82846ece61e2c7f903baf734de9fcb47f89f999c",
+                "reference": "82846ece61e2c7f903baf734de9fcb47f89f999c",
                 "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1.5",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
                 "psr/container": "^1.1.2 || ^2.0",
                 "psr/http-factory": "^1.0.2",
                 "psr/http-message": "^1.0.1 || ^2.0.0",
@@ -3334,13 +3334,13 @@
                 "zendframework/zend-expressive-router": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~3.0.1",
-                "laminas/laminas-diactoros": "^3.5.0",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-diactoros": "^3.6.0",
                 "laminas/laminas-servicemanager": "^4.4.0",
-                "laminas/laminas-stratigility": "^4.1.0",
-                "phpunit/phpunit": "^10.5.45",
+                "laminas/laminas-stratigility": "^4.2.0",
+                "phpunit/phpunit": "^11.5.42",
                 "psalm/plugin-phpunit": "^0.19.5",
-                "vimeo/psalm": "^6.10.1"
+                "vimeo/psalm": "^6.13.1"
             },
             "suggest": {
                 "mezzio/mezzio-fastroute": "^3.0 to use the FastRoute routing adapter",
@@ -3385,7 +3385,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-04-27T09:36:28+00:00"
+            "time": "2025-10-11T09:16:49+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -3851,30 +3851,31 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.22.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "35f1adb388946d92e6edab2aa2cb2b60e132ebd5"
+                "reference": "8cce4df9a20660cdc671e8f45ac61959ecdde8e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/35f1adb388946d92e6edab2aa2cb2b60e132ebd5",
-                "reference": "35f1adb388946d92e6edab2aa2cb2b60e132ebd5",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/8cce4df9a20660cdc671e8f45ac61959ecdde8e8",
+                "reference": "8cce4df9a20660cdc671e8f45ac61959ecdde8e8",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2 || ^2.0",
-                "php": "^7.4 || 8.0.* || 8.1.* || 8.2.* || 8.3.* || 8.4.*",
+                "php": "8.2.* || 8.3.* || 8.4.*",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
-                "sebastian/recursion-context": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "sebastian/recursion-context": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.1"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.40",
-                "phpspec/phpspec": "^6.0 || ^7.0",
+                "friendsofphp/php-cs-fixer": "^3.88",
+                "phpspec/phpspec": "^6.0 || ^7.0 || ^8.0",
                 "phpstan/phpstan": "^2.1.13",
-                "phpunit/phpunit": "^8.0 || ^9.0 || ^10.0"
+                "phpunit/phpunit": "^11.0 || ^12.0"
             },
             "type": "library",
             "extra": {
@@ -3915,9 +3916,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.22.0"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.23.0"
             },
-            "time": "2025-04-29T14:58:06+00:00"
+            "time": "2025-10-08T08:50:26+00:00"
         },
         {
             "name": "phpspec/prophecy-phpunit",
@@ -6023,47 +6024,47 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.26",
+            "version": "v7.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "492de6dfd93910d7d7a729c5a04ddcd2b9e99c4f"
+                "reference": "2b9c5fafbac0399a20a2e82429e2bd735dcfb7db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/492de6dfd93910d7d7a729c5a04ddcd2b9e99c4f",
-                "reference": "492de6dfd93910d7d7a729c5a04ddcd2b9e99c4f",
+                "url": "https://api.github.com/repos/symfony/console/zipball/2b9c5fafbac0399a20a2e82429e2bd735dcfb7db",
+                "reference": "2b9c5fafbac0399a20a2e82429e2bd735dcfb7db",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^5.4|^6.0|^7.0"
+                "symfony/string": "^7.2"
             },
             "conflict": {
-                "symfony/dependency-injection": "<5.4",
-                "symfony/dotenv": "<5.4",
-                "symfony/event-dispatcher": "<5.4",
-                "symfony/lock": "<5.4",
-                "symfony/process": "<5.4"
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
                 "symfony/http-foundation": "^6.4|^7.0",
                 "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/lock": "^5.4|^6.0|^7.0",
-                "symfony/messenger": "^5.4|^6.0|^7.0",
-                "symfony/process": "^5.4|^6.0|^7.0",
-                "symfony/stopwatch": "^5.4|^6.0|^7.0",
-                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+                "symfony/lock": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -6097,7 +6098,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.26"
+                "source": "https://github.com/symfony/console/tree/v7.3.4"
             },
             "funding": [
                 {
@@ -6117,7 +6118,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-26T12:13:46+00:00"
+            "time": "2025-09-22T15:31:00+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -6188,25 +6189,25 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.4.24",
+            "version": "v7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "75ae2edb7cdcc0c53766c30b0a2512b8df574bd8"
+                "reference": "edcbb768a186b5c3f25d0643159a787d3e63b7fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/75ae2edb7cdcc0c53766c30b0a2512b8df574bd8",
-                "reference": "75ae2edb7cdcc0c53766c30b0a2512b8df574bd8",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/edcbb768a186b5c3f25d0643159a787d3e63b7fd",
+                "reference": "edcbb768a186b5c3f25d0643159a787d3e63b7fd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
             "require-dev": {
-                "symfony/process": "^5.4|^6.4|^7.0"
+                "symfony/process": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -6234,7 +6235,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.4.24"
+                "source": "https://github.com/symfony/filesystem/tree/v7.3.2"
             },
             "funding": [
                 {
@@ -6254,7 +6255,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-10T08:14:14+00:00"
+            "time": "2025-07-07T08:17:47+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -6905,20 +6906,20 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.26",
+            "version": "v7.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "5621f039a71a11c87c106c1c598bdcd04a19aeea"
+                "reference": "f96476035142921000338bad71e5247fbc138872"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/5621f039a71a11c87c106c1c598bdcd04a19aeea",
-                "reference": "5621f039a71a11c87c106c1c598bdcd04a19aeea",
+                "url": "https://api.github.com/repos/symfony/string/zipball/f96476035142921000338bad71e5247fbc138872",
+                "reference": "f96476035142921000338bad71e5247fbc138872",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
@@ -6928,10 +6929,11 @@
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/http-client": "^5.4|^6.0|^7.0",
-                "symfony/intl": "^6.2|^7.0",
+                "symfony/emoji": "^7.1",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/intl": "^6.4|^7.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^5.4|^6.0|^7.0"
+                "symfony/var-exporter": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -6970,7 +6972,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.26"
+                "source": "https://github.com/symfony/string/tree/v7.3.4"
             },
             "funding": [
                 {
@@ -6990,7 +6992,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T14:32:46+00:00"
+            "time": "2025-09-11T14:36:48+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -7222,13 +7224,13 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "ext-dom": "*",
         "ext-json": "*"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1.99"
+        "php": "8.2.99"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -362,18 +362,10 @@
     </PossiblyFalseArgument>
   </file>
   <file src="src/ResourceGenerator/ExtractCollectionTrait.php">
-    <MethodSignatureMismatch>
-      <code><![CDATA[abstract protected function generateSelfLink(
-        AbstractCollectionMetadata $metadata,
-        ResourceGeneratorInterface $resourceGenerator,
-        ServerRequestInterface $request
-    ): Link;]]></code>
-      <code><![CDATA[abstract protected function generateSelfLink(
-        AbstractCollectionMetadata $metadata,
-        ResourceGeneratorInterface $resourceGenerator,
-        ServerRequestInterface $request
-    ): Link;]]></code>
-    </MethodSignatureMismatch>
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$resourceGenerator]]></code>
+      <code><![CDATA[$resourceGenerator]]></code>
+    </ArgumentTypeCoercion>
     <MixedArgument>
       <code><![CDATA[$item]]></code>
       <code><![CDATA[$item]]></code>
@@ -411,9 +403,6 @@
     </UndefinedMethod>
   </file>
   <file src="src/ResourceGenerator/RouteBasedCollectionStrategy.php">
-    <MethodSignatureMismatch>
-      <code><![CDATA[protected function generateSelfLink(]]></code>
-    </MethodSignatureMismatch>
     <MixedArgument>
       <code><![CDATA[$metadata->getQueryStringArguments()]]></code>
       <code><![CDATA[$metadata->getQueryStringArguments()]]></code>
@@ -432,6 +421,9 @@
       <code><![CDATA[$routeParams]]></code>
       <code><![CDATA[$routeParams]]></code>
     </MixedAssignment>
+    <MoreSpecificImplementedParamType>
+      <code><![CDATA[$resourceGenerator]]></code>
+    </MoreSpecificImplementedParamType>
     <UndefinedMethod>
       <code><![CDATA[getQueryStringArguments]]></code>
       <code><![CDATA[getQueryStringArguments]]></code>
@@ -450,9 +442,6 @@
     </MixedArrayOffset>
   </file>
   <file src="src/ResourceGenerator/UrlBasedCollectionStrategy.php">
-    <MethodSignatureMismatch>
-      <code><![CDATA[protected function generateSelfLink(]]></code>
-    </MethodSignatureMismatch>
     <MixedArgument>
       <code><![CDATA[$url]]></code>
     </MixedArgument>

--- a/src/ResourceGenerator/GenerateSelfLinkTrait.php
+++ b/src/ResourceGenerator/GenerateSelfLinkTrait.php
@@ -14,6 +14,8 @@ use Psr\Http\Message\ServerRequestInterface;
  * from the trait linked below, and their implementations, since that difference
  * now results in a fatal error in PHP 8.
  *
+ * @deprecated
+ *
  * @see ExtractCollectionTrait::generateSelfLink
  */
 trait GenerateSelfLinkTrait

--- a/src/ResourceGenerator/RouteBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/RouteBasedCollectionStrategy.php
@@ -7,6 +7,8 @@ namespace Mezzio\Hal\ResourceGenerator;
 use Mezzio\Hal\HalResource;
 use Mezzio\Hal\Link;
 use Mezzio\Hal\Metadata;
+use Mezzio\Hal\Metadata\AbstractCollectionMetadata;
+use Mezzio\Hal\ResourceGenerator;
 use Mezzio\Hal\ResourceGeneratorInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Traversable;
@@ -16,9 +18,7 @@ use function array_merge;
 /** @final */
 class RouteBasedCollectionStrategy implements StrategyInterface
 {
-    use ExtractCollectionTrait, GenerateSelfLinkTrait {
-        GenerateSelfLinkTrait::generateSelfLink insteadof ExtractCollectionTrait;
-    }
+    use ExtractCollectionTrait;
 
     public function createResource(
         object $instance,
@@ -43,20 +43,20 @@ class RouteBasedCollectionStrategy implements StrategyInterface
     }
 
     /**
-     * @param string $rel Relation to use when creating Link
-     * @param int $page Page number for generated link
-     * @param Metadata\AbstractCollectionMetadata $metadata Used to provide the
+     * @param string $rel                                   Relation to use when creating Link
+     * @param int $page                                     Page number for generated link
+     * @param AbstractCollectionMetadata $metadata          Used to provide the
      *     base URL, pagination parameter, and type of pagination used (query
      *     string, path parameter)
      * @param ResourceGeneratorInterface $resourceGenerator Used to retrieve link
      *     generator in order to generate link based on routing information.
-     * @param ServerRequestInterface $request Passed to link generator when
+     * @param ServerRequestInterface $request               Passed to link generator when
      *     generating link based on routing information.
      */
     protected function generateLinkForPage(
         string $rel,
         int $page,
-        Metadata\AbstractCollectionMetadata $metadata,
+        AbstractCollectionMetadata $metadata,
         ResourceGeneratorInterface $resourceGenerator,
         ServerRequestInterface $request
     ): Link {
@@ -67,10 +67,10 @@ class RouteBasedCollectionStrategy implements StrategyInterface
         $queryStringArgs = array_merge($request->getQueryParams(), $metadata->getQueryStringArguments());
 
         $paramsWithPage = [$paginationParam => $page];
-        $routeParams    = $paginationType === Metadata\AbstractCollectionMetadata::TYPE_PLACEHOLDER
+        $routeParams    = $paginationType === AbstractCollectionMetadata::TYPE_PLACEHOLDER
             ? array_merge($routeParams, $paramsWithPage)
             : $routeParams;
-        $queryParams    = $paginationType === Metadata\AbstractCollectionMetadata::TYPE_QUERY
+        $queryParams    = $paginationType === AbstractCollectionMetadata::TYPE_QUERY
             ? array_merge($queryStringArgs, $paramsWithPage)
             : $queryStringArgs;
 
@@ -86,15 +86,15 @@ class RouteBasedCollectionStrategy implements StrategyInterface
     }
 
     /**
-     * @param Metadata\AbstractCollectionMetadata $metadata Provides base URL
+     * @param AbstractCollectionMetadata $metadata Provides base URL
      *     for self link.
-     * @param ResourceGeneratorInterface $resourceGenerator Used to retrieve link
+     * @param ResourceGenerator $resourceGenerator Used to retrieve link
      *     generator in order to generate link based on routing information.
      * @param ServerRequestInterface $request Passed to link generator when
      *     generating link based on routing information.
      */
     protected function generateSelfLink(
-        Metadata\AbstractCollectionMetadata $metadata,
+        AbstractCollectionMetadata $metadata,
         ResourceGeneratorInterface $resourceGenerator,
         ServerRequestInterface $request
     ): Link {

--- a/src/ResourceGenerator/RouteBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/RouteBasedCollectionStrategy.php
@@ -92,13 +92,12 @@ class RouteBasedCollectionStrategy implements StrategyInterface
      *     generator in order to generate link based on routing information.
      * @param ServerRequestInterface $request Passed to link generator when
      *     generating link based on routing information.
-     * @return Link
      */
     protected function generateSelfLink(
         Metadata\AbstractCollectionMetadata $metadata,
         ResourceGeneratorInterface $resourceGenerator,
         ServerRequestInterface $request
-    ) {
+    ): Link {
         return $resourceGenerator
             ->getLinkGenerator()
             ->fromRoute(

--- a/src/ResourceGenerator/UrlBasedCollectionStrategy.php
+++ b/src/ResourceGenerator/UrlBasedCollectionStrategy.php
@@ -26,9 +26,7 @@ use const PHP_URL_QUERY;
 /** @final */
 class UrlBasedCollectionStrategy implements StrategyInterface
 {
-    use ExtractCollectionTrait, GenerateSelfLinkTrait {
-        GenerateSelfLinkTrait::generateSelfLink insteadof ExtractCollectionTrait;
-    }
+    use ExtractCollectionTrait;
 
     public function createResource(
         object $instance,
@@ -95,13 +93,12 @@ class UrlBasedCollectionStrategy implements StrategyInterface
      *     abstract.
      * @param ServerRequestInterface $request Ignored; required to fulfill
      *     abstract.
-     * @return Link
      */
     protected function generateSelfLink(
         Metadata\AbstractCollectionMetadata $metadata,
         ResourceGeneratorInterface $resourceGenerator,
         ServerRequestInterface $request
-    ) {
+    ): Link {
         $queryStringArgs = $request->getQueryParams();
         $url             = $metadata->getUrl();
         if ($queryStringArgs !== []) {


### PR DESCRIPTION
Leaving PHPUnit on 9.x until we can get rid of Prophecy

There's a technical BC Break here. `generateSelfLink` is declared abstract in 2 different traits with slightly different signatures.

IMO adding the return type is least worst option and means that the `GenerateSelfLinkTrait` is now unused so its been deprecated.